### PR TITLE
docs: remove "(coming soon)" from releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ bazel build //cmd/deplexity
 
 ### Pre-built binaries
 
-Download from [Releases](https://github.com/clappingmonkey/deplexity/releases) (coming soon).
+Download from [Releases](https://github.com/clappingmonkey/deplexity/releases).
 
 ---
 


### PR DESCRIPTION
## Description

Remove outdated "(coming soon)" text from the pre-built binaries section. Releases have been available since v0.2.2.

## Type of Change

- [x] Documentation

## Testing

- [x] Manual verification: link points to valid releases page

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Documentation-only change. No functional impact.