### PR TITLE
fix: resume incomplete thread exports

### DIFF
--- a/cmd/deplexity/BUILD.bazel
+++ b/cmd/deplexity/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "deplexity_lib",
@@ -24,4 +24,11 @@ go_binary(
         "main.version": "{STABLE_VERSION}",
         "main.buildTime": "{BUILD_TIMESTAMP}",
     },
+)
+
+go_test(
+    name = "deplexity_test",
+    srcs = ["main_test.go"],
+    embed = [":deplexity_lib"],
+    deps = ["//internal/models"],
 )

--- a/cmd/deplexity/BUILD.bazel
+++ b/cmd/deplexity/BUILD.bazel
@@ -30,5 +30,8 @@ go_test(
     name = "deplexity_test",
     srcs = ["main_test.go"],
     embed = [":deplexity_lib"],
-    deps = ["//internal/models"],
+    deps = [
+        "//internal/export",
+        "//internal/models",
+    ],
 )

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -98,6 +98,14 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 	fmt.Printf("Exporting to: %s\n", cmd.Output)
 	fmt.Printf("Formats: %v\n\n", cmd.Format)
 
+	// Validate the session before any network phase. A half-valid session lets
+	// the list endpoint return an empty result with no error, which would
+	// otherwise be cached as a complete, empty index and suppress later runs.
+	// Failing here surfaces the "run 'deplexity login'" message immediately.
+	if _, err := api.ValidateSession(ctx, c); err != nil {
+		return err
+	}
+
 	// === Phase 1: Thread index (list all UUIDs) ===
 	var threadRefs []models.ThreadRef
 	if cmd.Threads {
@@ -194,7 +202,7 @@ func (cmd *ExportCmd) fetchThreadIndex(ctx context.Context, c *client.Client, js
 		if err != nil {
 			return nil, err
 		}
-		if index != nil && index.Complete && time.Since(index.FetchedAt) < 24*time.Hour {
+		if indexServableFromCache(index) {
 			fmt.Printf("Using cached thread list (%d threads, fetched %s ago)\n", index.Total, time.Since(index.FetchedAt).Round(time.Minute))
 			return index.Threads, nil
 		}
@@ -238,13 +246,33 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 
 	fmt.Printf("\rFetching thread list... %d threads found\n", len(threads))
 
-	index.FetchedAt = time.Now().UTC()
-	index.Complete = true
-	if err := jsonExp.SaveThreadIndex(index); err != nil {
+	if err := finalizeIndex(jsonExp, index); err != nil {
 		return nil, err
 	}
 
 	return refs, nil
+}
+
+// indexServableFromCache reports whether a cached thread index can be reused
+// without re-listing. A complete index with zero threads is rejected even
+// though it is marked complete: it is either genuinely empty (cheap to re-list)
+// or a bogus empty index cached by an earlier half-valid session, and serving
+// it would keep an affected user broken for up to 24h. Requiring Total > 0
+// heals such poisoned caches on the next run without needing --refresh.
+func indexServableFromCache(index *models.ThreadIndex) bool {
+	return index != nil && index.Complete && index.Total > 0 &&
+		time.Since(index.FetchedAt) < 24*time.Hour
+}
+
+// finalizeIndex persists a fully-listed thread index, marking it complete only
+// when it actually contains threads. A half-valid session can make the list
+// endpoint return an empty result with no error; marking that complete would
+// cache a bogus empty index and suppress later runs for 24h (see fetchThreadIndex).
+// Leaving an empty result incomplete forces the next run to re-list.
+func finalizeIndex(jsonExp *export.JSONExporter, index *models.ThreadIndex) error {
+	index.FetchedAt = time.Now().UTC()
+	index.Complete = index.Total > 0
+	return jsonExp.SaveThreadIndex(index)
 }
 
 // continueListThreads resumes listing from a partial index.
@@ -274,9 +302,7 @@ func (cmd *ExportCmd) continueListThreads(ctx context.Context, c *client.Client,
 
 	fmt.Printf("\rFetching thread list... %d threads found\n", len(index.Threads))
 
-	index.FetchedAt = time.Now().UTC()
-	index.Complete = true
-	if err := jsonExp.SaveThreadIndex(index); err != nil {
+	if err := finalizeIndex(jsonExp, index); err != nil {
 		return nil, err
 	}
 

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -318,7 +318,18 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 			default:
 			}
 
-			full, err := api.GetThread(ctx, c, ref.UUID)
+			partial, err := jsonExp.LoadThread(ref.UUID)
+			if err != nil {
+				partial = nil
+			}
+			resume := resumePoint(cmd.Refresh, partial)
+			if resume != nil {
+				fmt.Printf("\n  Resuming thread %s from entry %d\n", ref.UUID, resume.NextOffset)
+			}
+
+			onPage := func(t *models.Thread) error { return jsonExp.ExportThread(t) }
+
+			full, err := api.GetThread(ctx, c, ref.UUID, resume, onPage)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "\n  Warning: could not fetch thread %s: %v\n", ref.UUID, err)
 				_ = bar.Add(1)
@@ -347,6 +358,16 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 	}
 
 	return threads, nil
+}
+
+// resumePoint reports the checkpoint an interrupted fetch should continue
+// from, or nil to fetch from the first page. Refresh runs never resume, since
+// entries cached before the thread changed may be stale.
+func resumePoint(refresh bool, partial *models.Thread) *models.Thread {
+	if refresh || partial == nil || partial.Complete || partial.NextOffset <= 0 {
+		return nil
+	}
+	return partial
 }
 
 func needsThreadFetch(refresh bool, ref models.ThreadRef, cached *models.Thread, err error) bool {

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -66,13 +66,13 @@ func (cmd *LoginCmd) Run(ctx context.Context) error {
 
 // ExportCmd handles data export.
 type ExportCmd struct {
-	Output  string   `short:"o" default:"deplexity-export" help:"Output directory."`
-	Format  []string `short:"f" default:"json,markdown" help:"Export formats (json, markdown, pdf)." enum:"json,markdown,pdf"`
-	Threads bool     `help:"Export threads." default:"true" negatable:""`
-	Spaces  bool     `help:"Export spaces/collections." default:"true" negatable:""`
-	Profile bool     `help:"Export user profile." default:"true" negatable:""`
+	Output     string   `short:"o" default:"deplexity-export" help:"Output directory."`
+	Format     []string `short:"f" default:"json,markdown" help:"Export formats (json, markdown, pdf)." enum:"json,markdown,pdf"`
+	Threads    bool     `help:"Export threads." default:"true" negatable:""`
+	Spaces     bool     `help:"Export spaces/collections." default:"true" negatable:""`
+	Profile    bool     `help:"Export user profile." default:"true" negatable:""`
 	Delay      int      `help:"Delay between API requests in milliseconds." default:"500"`
-	Refresh    bool     `help:"Force re-fetch of thread list even if cached." default:"false"`
+	Refresh    bool     `help:"Re-fetch the thread list and updated thread details." default:"false"`
 	PDFWorkers int      `help:"Number of parallel workers for PDF generation (0 = auto-detect CPU count)." default:"0" name:"pdf-workers"`
 
 	verbose bool // set by main before Run
@@ -214,6 +214,11 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 	fmt.Print("Fetching thread list...")
 
 	index := &models.ThreadIndex{Complete: false}
+	previous, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n  Warning: could not read cached thread list: %v\n", err)
+		previous = nil
+	}
 
 	threads, err := api.ListThreads(ctx, c, func(n int) {
 		fmt.Printf("\rFetching thread list... %d", n)
@@ -221,6 +226,9 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 
 	// Always save progress (even on error/interrupt)
 	refs := buildRefsFromThreads(threads)
+	if previous != nil {
+		attachPreviousUpdatedAt(refs, previous.Threads)
+	}
 	index.Threads = refs
 	index.Total = len(refs)
 	if err != nil {
@@ -255,7 +263,7 @@ func (cmd *ExportCmd) continueListThreads(ctx context.Context, c *client.Client,
 
 	// Merge results
 	for _, t := range additional {
-		index.Threads = append(index.Threads, models.ThreadRef{UUID: t.UUID, Title: t.Title, SpaceUUID: t.SpaceUUID})
+		index.Threads = append(index.Threads, models.ThreadRef{UUID: t.UUID, Title: t.Title, SpaceUUID: t.SpaceUUID, UpdatedAt: t.UpdatedAt})
 	}
 	index.Total = len(index.Threads)
 
@@ -278,17 +286,18 @@ func (cmd *ExportCmd) continueListThreads(ctx context.Context, c *client.Client,
 func buildRefsFromThreads(threads []models.Thread) []models.ThreadRef {
 	refs := make([]models.ThreadRef, 0, len(threads))
 	for _, t := range threads {
-		refs = append(refs, models.ThreadRef{UUID: t.UUID, Title: t.Title, SpaceUUID: t.SpaceUUID})
+		refs = append(refs, models.ThreadRef{UUID: t.UUID, Title: t.Title, SpaceUUID: t.SpaceUUID, UpdatedAt: t.UpdatedAt})
 	}
 	return refs
 }
 
-// fetchThreadDetails fetches full details for threads not yet on disk.
+// fetchThreadDetails fetches full details for incomplete or changed threads.
 func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, jsonExp *export.JSONExporter, refs []models.ThreadRef) ([]models.Thread, error) {
 	// Determine which threads need fetching
 	var missing []models.ThreadRef
 	for _, ref := range refs {
-		if !jsonExp.ThreadDetailExists(ref.UUID) {
+		cached, err := jsonExp.LoadCompleteThread(ref.UUID)
+		if needsThreadFetch(cmd.Refresh, ref, cached, err) {
 			missing = append(missing, ref)
 		}
 	}
@@ -330,7 +339,7 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 	// Load all threads from disk
 	threads := make([]models.Thread, 0, len(refs))
 	for _, ref := range refs {
-		t, err := jsonExp.LoadThread(ref.UUID)
+		t, err := jsonExp.LoadCompleteThread(ref.UUID)
 		if err != nil {
 			continue // skip threads that failed to fetch
 		}
@@ -338,6 +347,23 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 	}
 
 	return threads, nil
+}
+
+func needsThreadFetch(refresh bool, ref models.ThreadRef, cached *models.Thread, err error) bool {
+	if err != nil || cached == nil {
+		return true
+	}
+	return refresh && (ref.UpdatedAt.IsZero() || ref.PreviousUpdatedAt.IsZero() || ref.UpdatedAt.After(ref.PreviousUpdatedAt))
+}
+
+func attachPreviousUpdatedAt(refs []models.ThreadRef, previous []models.ThreadRef) {
+	previousByUUID := make(map[string]time.Time, len(previous))
+	for _, ref := range previous {
+		previousByUUID[ref.UUID] = ref.UpdatedAt
+	}
+	for i := range refs {
+		refs[i].PreviousUpdatedAt = previousByUUID[refs[i].UUID]
+	}
 }
 
 func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads []models.Thread, spaces []models.Space, user *models.User) error {

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -324,7 +324,7 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 			}
 			resume := resumePoint(cmd.Refresh, partial)
 			if resume != nil {
-				fmt.Printf("\n  Resuming thread %s from entry %d\n", ref.UUID, resume.NextOffset)
+				fmt.Printf("\n  Resuming thread %s (%d entries so far)\n", ref.UUID, len(resume.Entries))
 			}
 
 			onPage := func(t *models.Thread) error { return jsonExp.ExportThread(t) }
@@ -364,7 +364,7 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 // from, or nil to fetch from the first page. Refresh runs never resume, since
 // entries cached before the thread changed may be stale.
 func resumePoint(refresh bool, partial *models.Thread) *models.Thread {
-	if refresh || partial == nil || partial.Complete || partial.NextOffset <= 0 {
+	if refresh || partial == nil || partial.Complete || partial.NextCursor == "" {
 		return nil
 	}
 	return partial

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
+
+func TestNeedsThreadFetch(t *testing.T) {
+	previous := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	current := previous.Add(time.Hour)
+	cached := &models.Thread{Complete: true}
+
+	tests := []struct {
+		name    string
+		refresh bool
+		ref     models.ThreadRef
+		cached  *models.Thread
+		err     error
+		want    bool
+	}{
+		{name: "missing cached detail", err: errors.New("not found"), want: true},
+		{name: "unchanged without refresh", ref: models.ThreadRef{UpdatedAt: current, PreviousUpdatedAt: previous}, cached: cached, want: false},
+		{name: "unchanged with refresh", refresh: true, ref: models.ThreadRef{UpdatedAt: previous, PreviousUpdatedAt: previous}, cached: cached, want: false},
+		{name: "newer with refresh", refresh: true, ref: models.ThreadRef{UpdatedAt: current, PreviousUpdatedAt: previous}, cached: cached, want: true},
+		{name: "unknown current timestamp", refresh: true, ref: models.ThreadRef{PreviousUpdatedAt: previous}, cached: cached, want: true},
+		{name: "legacy index timestamp", refresh: true, ref: models.ThreadRef{UpdatedAt: current}, cached: cached, want: true},
+		{name: "nil cached thread", refresh: true, ref: models.ThreadRef{UpdatedAt: current, PreviousUpdatedAt: previous}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsThreadFetch(tt.refresh, tt.ref, tt.cached, tt.err); got != tt.want {
+				t.Errorf("needsThreadFetch() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAttachPreviousUpdatedAt(t *testing.T) {
+	previous := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	refs := []models.ThreadRef{{UUID: "unchanged"}, {UUID: "new"}}
+	attachPreviousUpdatedAt(refs, []models.ThreadRef{{UUID: "unchanged", UpdatedAt: previous}})
+
+	if !refs[0].PreviousUpdatedAt.Equal(previous) {
+		t.Errorf("PreviousUpdatedAt = %v, want %v", refs[0].PreviousUpdatedAt, previous)
+	}
+	if !refs[1].PreviousUpdatedAt.IsZero() {
+		t.Errorf("PreviousUpdatedAt = %v, want zero time", refs[1].PreviousUpdatedAt)
+	}
+}

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/clappingmonkey/deplexity/internal/export"
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
@@ -75,5 +76,71 @@ func TestAttachPreviousUpdatedAt(t *testing.T) {
 	}
 	if !refs[1].PreviousUpdatedAt.IsZero() {
 		t.Errorf("PreviousUpdatedAt = %v, want zero time", refs[1].PreviousUpdatedAt)
+	}
+}
+
+func TestIndexServableFromCache(t *testing.T) {
+	fresh := time.Now().UTC()
+	stale := fresh.Add(-25 * time.Hour)
+
+	tests := []struct {
+		name  string
+		index *models.ThreadIndex
+		want  bool
+	}{
+		{name: "nil index", index: nil, want: false},
+		{name: "complete with threads", index: &models.ThreadIndex{Complete: true, Total: 3, FetchedAt: fresh}, want: true},
+		{name: "poisoned empty complete index", index: &models.ThreadIndex{Complete: true, Total: 0, FetchedAt: fresh}, want: false},
+		{name: "incomplete index", index: &models.ThreadIndex{Complete: false, Total: 3, FetchedAt: fresh}, want: false},
+		{name: "expired cache", index: &models.ThreadIndex{Complete: true, Total: 3, FetchedAt: stale}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := indexServableFromCache(tt.index); got != tt.want {
+				t.Errorf("indexServableFromCache() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFinalizeIndex(t *testing.T) {
+	tests := []struct {
+		name         string
+		total        int
+		wantComplete bool
+	}{
+		{name: "empty result stays incomplete", total: 0, wantComplete: false},
+		{name: "populated result is complete", total: 3, wantComplete: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+			index := &models.ThreadIndex{Total: tt.total}
+
+			if err := finalizeIndex(jsonExp, index); err != nil {
+				t.Fatalf("finalizeIndex: %v", err)
+			}
+			if index.Complete != tt.wantComplete {
+				t.Errorf("Complete = %t, want %t", index.Complete, tt.wantComplete)
+			}
+			if index.FetchedAt.IsZero() {
+				t.Error("FetchedAt not stamped")
+			}
+
+			// The persisted index must round-trip the same completion state, so
+			// an empty result cannot be served from cache on the next run.
+			reloaded, err := jsonExp.LoadThreadIndex()
+			if err != nil {
+				t.Fatalf("LoadThreadIndex: %v", err)
+			}
+			if reloaded == nil {
+				t.Fatal("index was not persisted")
+			}
+			if reloaded.Complete != tt.wantComplete {
+				t.Errorf("persisted Complete = %t, want %t", reloaded.Complete, tt.wantComplete)
+			}
+		})
 	}
 }

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -39,6 +39,32 @@ func TestNeedsThreadFetch(t *testing.T) {
 	}
 }
 
+func TestResumePoint(t *testing.T) {
+	partial := &models.Thread{NextOffset: 50}
+
+	tests := []struct {
+		name    string
+		refresh bool
+		partial *models.Thread
+		want    bool
+	}{
+		{name: "interrupted fetch", partial: partial, want: true},
+		{name: "refresh discards checkpoint", refresh: true, partial: partial},
+		{name: "no partial on disk"},
+		{name: "already complete", partial: &models.Thread{Complete: true, NextOffset: 50}},
+		{name: "no progress recorded", partial: &models.Thread{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resumePoint(tt.refresh, tt.partial)
+			if (got != nil) != tt.want {
+				t.Errorf("resumePoint() = %v, want non-nil %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAttachPreviousUpdatedAt(t *testing.T) {
 	previous := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 	refs := []models.ThreadRef{{UUID: "unchanged"}, {UUID: "new"}}

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -40,7 +40,7 @@ func TestNeedsThreadFetch(t *testing.T) {
 }
 
 func TestResumePoint(t *testing.T) {
-	partial := &models.Thread{NextOffset: 50}
+	partial := &models.Thread{NextCursor: "c1"}
 
 	tests := []struct {
 		name    string
@@ -51,7 +51,7 @@ func TestResumePoint(t *testing.T) {
 		{name: "interrupted fetch", partial: partial, want: true},
 		{name: "refresh discards checkpoint", refresh: true, partial: partial},
 		{name: "no partial on disk"},
-		{name: "already complete", partial: &models.Thread{Complete: true, NextOffset: 50}},
+		{name: "already complete", partial: &models.Thread{Complete: true, NextCursor: "c1"}},
 		{name: "no progress recorded", partial: &models.Thread{}},
 	}
 

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -18,7 +18,10 @@ go_library(
 
 go_test(
     name = "api_test",
-    srcs = ["threads_test.go"],
+    srcs = [
+        "threads_test.go",
+        "user_test.go",
+    ],
     embed = [":api"],
     deps = ["//internal/models"],
 )

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -20,4 +20,5 @@ go_test(
     name = "api_test",
     srcs = ["threads_test.go"],
     embed = [":api"],
+    deps = ["//internal/models"],
 )

--- a/internal/api/threads.go
+++ b/internal/api/threads.go
@@ -11,6 +11,12 @@ import (
 
 const apiVersion = "2.18"
 
+// maxStalePages bounds how many consecutive detail pages may contain only
+// already-seen entries before the fetch concludes the API is recycling
+// results. Pages can legitimately overlap, so a single stale page is not
+// treated as the end of a thread.
+const maxStalePages = 3
+
 type getter interface {
 	Get(context.Context, string, any) error
 }
@@ -98,121 +104,156 @@ func ListThreads(ctx context.Context, c *client.Client, onProgress func(int)) ([
 	return ListThreadsFrom(ctx, c, 0, make(map[string]bool), onProgress)
 }
 
+// threadPagePath builds the detail endpoint URL for a single page of a thread.
+func threadPagePath(uuid string, offset int) string {
+	return fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=%d&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion, offset)
+}
+
+// toEntry converts a raw API thread entry into the exported model.
+func toEntry(e ThreadEntry) models.Entry {
+	entry := models.Entry{
+		UUID:        e.UUID,
+		Query:       e.QueryStr,
+		Model:       e.DisplayModel,
+		SearchFocus: e.SearchFocus,
+		CreatedAt:   parseTime(e.CreatedAt),
+	}
+
+	// Extract markdown answer from blocks (prefer ask_text_0_markdown over ask_text).
+	for _, b := range e.Blocks {
+		if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text_0_markdown" && b.MarkdownBlock.Answer != "" {
+			entry.Answer = b.MarkdownBlock.Answer
+			break
+		}
+	}
+	if entry.Answer == "" {
+		for _, b := range e.Blocks {
+			if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text" && b.MarkdownBlock.Answer != "" {
+				entry.Answer = b.MarkdownBlock.Answer
+				break
+			}
+		}
+	}
+
+	// Extract sources from web_results block.
+	for _, b := range e.Blocks {
+		if b.WebResultBlock != nil && b.IntendedUsage == "web_results" {
+			for _, wr := range b.WebResultBlock.WebResults {
+				entry.Sources = append(entry.Sources, models.Source{
+					Title:   wr.Name,
+					URL:     wr.URL,
+					Snippet: wr.Snippet,
+				})
+			}
+			break
+		}
+	}
+
+	return entry
+}
+
 // GetThread fetches the full detail of a single thread including all entries.
-func GetThread(ctx context.Context, c getter, uuid string) (*models.Thread, error) {
-	var raw ThreadDetailResponse
-	path := fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=0&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion)
-	if err := c.Get(ctx, path, &raw); err != nil {
-		return nil, fmt.Errorf("failed to get thread %s: %w", uuid, err)
+//
+// If resume is a previously persisted incomplete thread, fetching continues
+// from its NextOffset instead of restarting from the beginning. onPage, when
+// non-nil, is called after each fetched page so the caller can checkpoint
+// progress; a page fetch failure leaves the last checkpoint on disk to be
+// resumed by a later run.
+func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread, onPage func(*models.Thread) error) (*models.Thread, error) {
+	thread := &models.Thread{UUID: uuid, Slug: uuid}
+	offset := 0
+	seen := make(map[string]bool)
+	resuming := false
+	staleStreak := 0
+
+	if resume != nil && !resume.Complete && resume.NextOffset > 0 {
+		resuming = true
+		thread.Title = resume.Title
+		thread.CreatedAt = resume.CreatedAt
+		thread.UpdatedAt = resume.UpdatedAt
+		thread.SpaceUUID = resume.SpaceUUID
+		thread.Bookmarked = resume.Bookmarked
+		thread.Entries = append(thread.Entries, resume.Entries...)
+		for _, e := range thread.Entries {
+			seen[e.UUID] = true
+		}
+		offset = resume.NextOffset
 	}
 
-	thread := &models.Thread{
-		UUID:      uuid,
-		Slug:      uuid,
-		Title:     raw.ThreadMetadata.Title,
-		CreatedAt: parseTime(raw.ThreadMetadata.CreatedAt),
-		UpdatedAt: parseTime(raw.ThreadMetadata.UpdatedAt),
-	}
-
-	for _, e := range raw.Entries {
-		entry := models.Entry{
-			UUID:        e.UUID,
-			Query:       e.QueryStr,
-			Model:       e.DisplayModel,
-			SearchFocus: e.SearchFocus,
-			CreatedAt:   parseTime(e.CreatedAt),
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
 		}
 
-		// Extract markdown answer from blocks (prefer ask_text_0_markdown over ask_text).
-		for _, b := range e.Blocks {
-			if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text_0_markdown" {
-				if b.MarkdownBlock.Answer != "" {
-					entry.Answer = b.MarkdownBlock.Answer
-					break
-				}
+		var page ThreadDetailResponse
+		if err := c.Get(ctx, threadPagePath(uuid, offset), &page); err != nil {
+			return nil, fmt.Errorf("failed to get thread %s page at offset %d: %w", uuid, offset, err)
+		}
+
+		// A resumed offset past the end of the thread returns nothing, which
+		// means the checkpoint is stale. Restart from the beginning rather
+		// than marking a truncated thread complete. Only the first resumed
+		// request can trigger this, so the restart cannot repeat.
+		if resuming && len(page.Entries) == 0 {
+			resuming = false
+			thread = &models.Thread{UUID: uuid, Slug: uuid}
+			seen = make(map[string]bool)
+			offset = 0
+			continue
+		}
+		resuming = false
+
+		// Metadata only comes back reliably on the first page of a run.
+		if thread.Title == "" {
+			thread.Title = page.ThreadMetadata.Title
+		}
+		if thread.CreatedAt.IsZero() {
+			thread.CreatedAt = parseTime(page.ThreadMetadata.CreatedAt)
+		}
+		if thread.UpdatedAt.IsZero() {
+			thread.UpdatedAt = parseTime(page.ThreadMetadata.UpdatedAt)
+		}
+
+		// The API recycles results across pages, so skip entries already held.
+		newCount := 0
+		for _, e := range page.Entries {
+			if seen[e.UUID] {
+				continue
 			}
-		}
-		if entry.Answer == "" {
-			for _, b := range e.Blocks {
-				if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text" {
-					if b.MarkdownBlock.Answer != "" {
-						entry.Answer = b.MarkdownBlock.Answer
-						break
-					}
-				}
-			}
+			seen[e.UUID] = true
+			newCount++
+			thread.Entries = append(thread.Entries, toEntry(e))
 		}
 
-		// Extract sources from web_results block.
-		for _, b := range e.Blocks {
-			if b.WebResultBlock != nil && b.IntendedUsage == "web_results" {
-				for _, wr := range b.WebResultBlock.WebResults {
-					entry.Sources = append(entry.Sources, models.Source{
-						Title:   wr.Name,
-						URL:     wr.URL,
-						Snippet: wr.Snippet,
-					})
-				}
+		if !page.HasNextPage || len(page.Entries) == 0 {
+			break
+		}
+
+		// Pages can overlap, so a single page with nothing new does not prove
+		// the thread has ended. Tolerate a bounded run of them before treating
+		// the API as recycling, which also guarantees termination.
+		if newCount == 0 {
+			staleStreak++
+			if staleStreak >= maxStalePages {
 				break
 			}
+		} else {
+			staleStreak = 0
 		}
 
-		thread.Entries = append(thread.Entries, entry)
-	}
-
-	// Fetch remaining pages if needed.
-	if raw.HasNextPage {
-		offset := len(raw.Entries)
-		for {
-			var page ThreadDetailResponse
-			pagePath := fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=%d&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion, offset)
-			if err := c.Get(ctx, pagePath, &page); err != nil {
-				return nil, fmt.Errorf("failed to get thread %s page at offset %d: %w", uuid, offset, err)
+		offset += len(page.Entries)
+		thread.NextOffset = offset
+		if onPage != nil {
+			if err := onPage(thread); err != nil {
+				return nil, fmt.Errorf("failed to checkpoint thread %s at offset %d: %w", uuid, offset, err)
 			}
-			for _, e := range page.Entries {
-				entry := models.Entry{
-					UUID:        e.UUID,
-					Query:       e.QueryStr,
-					Model:       e.DisplayModel,
-					SearchFocus: e.SearchFocus,
-					CreatedAt:   parseTime(e.CreatedAt),
-				}
-				for _, b := range e.Blocks {
-					if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text_0_markdown" && b.MarkdownBlock.Answer != "" {
-						entry.Answer = b.MarkdownBlock.Answer
-						break
-					}
-				}
-				if entry.Answer == "" {
-					for _, b := range e.Blocks {
-						if b.MarkdownBlock != nil && b.IntendedUsage == "ask_text" && b.MarkdownBlock.Answer != "" {
-							entry.Answer = b.MarkdownBlock.Answer
-							break
-						}
-					}
-				}
-				for _, b := range e.Blocks {
-					if b.WebResultBlock != nil && b.IntendedUsage == "web_results" {
-						for _, wr := range b.WebResultBlock.WebResults {
-							entry.Sources = append(entry.Sources, models.Source{
-								Title:   wr.Name,
-								URL:     wr.URL,
-								Snippet: wr.Snippet,
-							})
-						}
-						break
-					}
-				}
-				thread.Entries = append(thread.Entries, entry)
-			}
-			if !page.HasNextPage {
-				break
-			}
-			offset += len(page.Entries)
 		}
 	}
 
 	thread.Complete = true
+	thread.NextOffset = 0
 	return thread, nil
 }
 

--- a/internal/api/threads.go
+++ b/internal/api/threads.go
@@ -11,6 +11,10 @@ import (
 
 const apiVersion = "2.18"
 
+type getter interface {
+	Get(context.Context, string, any) error
+}
+
 // ListThreadsFrom fetches threads starting at a given offset via POST /rest/thread/list_ask_threads.
 // Stops when a page returns fewer than limit results (end of data) or when all results are
 // duplicates (safety net for API recycling behavior).
@@ -95,7 +99,7 @@ func ListThreads(ctx context.Context, c *client.Client, onProgress func(int)) ([
 }
 
 // GetThread fetches the full detail of a single thread including all entries.
-func GetThread(ctx context.Context, c *client.Client, uuid string) (*models.Thread, error) {
+func GetThread(ctx context.Context, c getter, uuid string) (*models.Thread, error) {
 	var raw ThreadDetailResponse
 	path := fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=0&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion)
 	if err := c.Get(ctx, path, &raw); err != nil {
@@ -163,7 +167,7 @@ func GetThread(ctx context.Context, c *client.Client, uuid string) (*models.Thre
 			var page ThreadDetailResponse
 			pagePath := fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=%d&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion, offset)
 			if err := c.Get(ctx, pagePath, &page); err != nil {
-				break // best effort
+				return nil, fmt.Errorf("failed to get thread %s page at offset %d: %w", uuid, offset, err)
 			}
 			for _, e := range page.Entries {
 				entry := models.Entry{
@@ -208,6 +212,7 @@ func GetThread(ctx context.Context, c *client.Client, uuid string) (*models.Thre
 		}
 	}
 
+	thread.Complete = true
 	return thread, nil
 }
 

--- a/internal/api/threads.go
+++ b/internal/api/threads.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/clappingmonkey/deplexity/internal/client"
@@ -10,12 +11,6 @@ import (
 )
 
 const apiVersion = "2.18"
-
-// maxStalePages bounds how many consecutive detail pages may contain only
-// already-seen entries before the fetch concludes the API is recycling
-// results. Pages can legitimately overlap, so a single stale page is not
-// treated as the end of a thread.
-const maxStalePages = 3
 
 type getter interface {
 	Get(context.Context, string, any) error
@@ -105,8 +100,18 @@ func ListThreads(ctx context.Context, c *client.Client, onProgress func(int)) ([
 }
 
 // threadPagePath builds the detail endpoint URL for a single page of a thread.
-func threadPagePath(uuid string, offset int) string {
-	return fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=50&offset=%d&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion, offset)
+//
+// The endpoint ignores the offset parameter and paginates by cursor: each
+// response returns a next_cursor that must be passed back verbatim. offset is
+// pinned to 0, mirroring the browser. The cursor is URL-encoded JSON, so it is
+// escaped here because the HTTP client concatenates the path onto the base URL
+// without any encoding of its own.
+func threadPagePath(uuid, cursor string) string {
+	path := fmt.Sprintf("/rest/thread/%s?with_schematized_response=true&version=%s&source=default&limit=100&offset=0&from_first=true&supported_block_use_cases=answer_modes&supported_block_use_cases=preserve_latex", uuid, apiVersion)
+	if cursor != "" {
+		path += "&cursor=" + url.QueryEscape(cursor)
+	}
+	return path
 }
 
 // toEntry converts a raw API thread entry into the exported model.
@@ -154,20 +159,21 @@ func toEntry(e ThreadEntry) models.Entry {
 
 // GetThread fetches the full detail of a single thread including all entries.
 //
-// If resume is a previously persisted incomplete thread, fetching continues
-// from its NextOffset instead of restarting from the beginning. onPage, when
-// non-nil, is called after each fetched page so the caller can checkpoint
-// progress; a page fetch failure leaves the last checkpoint on disk to be
-// resumed by a later run.
+// The detail endpoint paginates by cursor: each response carries a next_cursor
+// that is passed back to fetch the following page. If resume is a previously
+// persisted incomplete thread, fetching continues from its NextCursor instead
+// of restarting. onPage, when non-nil, is called after each fetched page so the
+// caller can checkpoint progress; a page fetch failure leaves the last
+// checkpoint on disk to be resumed by a later run.
 func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread, onPage func(*models.Thread) error) (*models.Thread, error) {
 	thread := &models.Thread{UUID: uuid, Slug: uuid}
-	offset := 0
+	cursor := ""
 	seen := make(map[string]bool)
-	resuming := false
-	staleStreak := 0
+	// seenCursors bounds the loop: the endpoint is reverse-engineered, so a
+	// misbehaving response that repeats a cursor must not spin forever.
+	seenCursors := make(map[string]bool)
 
-	if resume != nil && !resume.Complete && resume.NextOffset > 0 {
-		resuming = true
+	if resume != nil && !resume.Complete && resume.NextCursor != "" {
 		thread.Title = resume.Title
 		thread.CreatedAt = resume.CreatedAt
 		thread.UpdatedAt = resume.UpdatedAt
@@ -177,7 +183,8 @@ func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread
 		for _, e := range thread.Entries {
 			seen[e.UUID] = true
 		}
-		offset = resume.NextOffset
+		cursor = resume.NextCursor
+		seenCursors[cursor] = true
 	}
 
 	for {
@@ -188,22 +195,9 @@ func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread
 		}
 
 		var page ThreadDetailResponse
-		if err := c.Get(ctx, threadPagePath(uuid, offset), &page); err != nil {
-			return nil, fmt.Errorf("failed to get thread %s page at offset %d: %w", uuid, offset, err)
+		if err := c.Get(ctx, threadPagePath(uuid, cursor), &page); err != nil {
+			return nil, fmt.Errorf("failed to get thread %s page: %w", uuid, err)
 		}
-
-		// A resumed offset past the end of the thread returns nothing, which
-		// means the checkpoint is stale. Restart from the beginning rather
-		// than marking a truncated thread complete. Only the first resumed
-		// request can trigger this, so the restart cannot repeat.
-		if resuming && len(page.Entries) == 0 {
-			resuming = false
-			thread = &models.Thread{UUID: uuid, Slug: uuid}
-			seen = make(map[string]bool)
-			offset = 0
-			continue
-		}
-		resuming = false
 
 		// Metadata only comes back reliably on the first page of a run.
 		if thread.Title == "" {
@@ -216,44 +210,41 @@ func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread
 			thread.UpdatedAt = parseTime(page.ThreadMetadata.UpdatedAt)
 		}
 
-		// The API recycles results across pages, so skip entries already held.
-		newCount := 0
+		// A cursor boundary can re-include the last entry, so dedupe by UUID.
 		for _, e := range page.Entries {
 			if seen[e.UUID] {
 				continue
 			}
 			seen[e.UUID] = true
-			newCount++
 			thread.Entries = append(thread.Entries, toEntry(e))
 		}
 
-		if !page.HasNextPage || len(page.Entries) == 0 {
+		// The thread ends when the API reports no further page or omits the
+		// next cursor. Both are checked to guard against inconsistent responses.
+		if !page.HasNextPage || page.NextCursor == nil || *page.NextCursor == "" {
 			break
 		}
 
-		// Pages can overlap, so a single page with nothing new does not prove
-		// the thread has ended. Tolerate a bounded run of them before treating
-		// the API as recycling, which also guarantees termination.
-		if newCount == 0 {
-			staleStreak++
-			if staleStreak >= maxStalePages {
-				break
-			}
-		} else {
-			staleStreak = 0
+		cursor = *page.NextCursor
+		// A cursor that has already been used this run means the API is not
+		// advancing. Stop with an error so the last good checkpoint on disk is
+		// preserved for a later resume instead of looping or marking the
+		// partially-fetched thread complete.
+		if seenCursors[cursor] {
+			return nil, fmt.Errorf("thread %s did not advance past cursor: possible API pagination loop", uuid)
 		}
+		seenCursors[cursor] = true
 
-		offset += len(page.Entries)
-		thread.NextOffset = offset
+		thread.NextCursor = cursor
 		if onPage != nil {
 			if err := onPage(thread); err != nil {
-				return nil, fmt.Errorf("failed to checkpoint thread %s at offset %d: %w", uuid, offset, err)
+				return nil, fmt.Errorf("failed to checkpoint thread %s: %w", uuid, err)
 			}
 		}
 	}
 
 	thread.Complete = true
-	thread.NextOffset = 0
+	thread.NextCursor = ""
 	return thread, nil
 }
 

--- a/internal/api/threads_test.go
+++ b/internal/api/threads_test.go
@@ -1,9 +1,26 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
+
+type threadGetter struct {
+	responses []ThreadDetailResponse
+	calls     int
+}
+
+func (g *threadGetter) Get(_ context.Context, _ string, dst any) error {
+	if g.calls >= len(g.responses) {
+		return errors.New("rate limited")
+	}
+	*dst.(*ThreadDetailResponse) = g.responses[g.calls]
+	g.calls++
+	return nil
+}
 
 func TestParseTime(t *testing.T) {
 	tests := []struct {
@@ -66,5 +83,24 @@ func TestThreadListItemMapping(t *testing.T) {
 	}
 	if raw.Title != "Test Thread" {
 		t.Errorf("unexpected Title: %s", raw.Title)
+	}
+}
+
+func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		Entries:        []ThreadEntry{{UUID: "entry-1"}},
+		HasNextPage:    true,
+	}}}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1")
+	if err == nil {
+		t.Fatal("GetThread succeeded after a later page failed")
+	}
+	if thread != nil {
+		t.Fatalf("GetThread returned a partial thread: %+v", thread)
+	}
+	if !strings.Contains(err.Error(), "offset 1") {
+		t.Errorf("error = %q, want offset context", err)
 	}
 }

--- a/internal/api/threads_test.go
+++ b/internal/api/threads_test.go
@@ -90,11 +90,117 @@ func TestThreadListItemMapping(t *testing.T) {
 	}
 }
 
+func cursorPtr(s string) *string { return &s }
+
+func TestThreadPagePathEscapesCursor(t *testing.T) {
+	cursor := `{"M":{"entry_uuid":{"S":"abc"}}}`
+	path := threadPagePath("thread-1", cursor)
+
+	if !strings.Contains(path, "offset=0") {
+		t.Errorf("path = %q, want offset pinned to 0", path)
+	}
+	if !strings.Contains(path, "limit=100") {
+		t.Errorf("path = %q, want limit=100", path)
+	}
+	if !strings.Contains(path, "cursor=%7B%22M%22") {
+		t.Errorf("path = %q, want URL-escaped cursor", path)
+	}
+	if strings.Contains(path, cursor) {
+		t.Errorf("path = %q, want the raw cursor JSON escaped", path)
+	}
+}
+
+func TestThreadPagePathOmitsEmptyCursor(t *testing.T) {
+	if path := threadPagePath("thread-1", ""); strings.Contains(path, "cursor=") {
+		t.Errorf("path = %q, want no cursor param on the first page", path)
+	}
+}
+
+func TestGetThreadPaginatesByCursor(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{
+		{
+			ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+			Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+			HasNextPage:    true,
+			NextCursor:     cursorPtr("cursor-1"),
+		},
+		{
+			// A cursor boundary re-includes the last entry of the prior page.
+			Entries:     []ThreadEntry{{UUID: "entry-2"}, {UUID: "entry-3"}},
+			HasNextPage: false,
+			NextCursor:  cursorPtr(""),
+		},
+	}}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if getter.calls != 2 {
+		t.Errorf("made %d requests, want 2", getter.calls)
+	}
+	if strings.Contains(getter.paths[0], "cursor=") {
+		t.Errorf("first request = %q, want no cursor", getter.paths[0])
+	}
+	if !strings.Contains(getter.paths[1], "cursor=cursor-1") {
+		t.Errorf("second request = %q, want cursor from first page", getter.paths[1])
+	}
+
+	want := []string{"entry-1", "entry-2", "entry-3"}
+	if len(thread.Entries) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(thread.Entries), len(want), thread.Entries)
+	}
+	for i, uuid := range want {
+		if thread.Entries[i].UUID != uuid {
+			t.Errorf("entry %d = %q, want %q", i, thread.Entries[i].UUID, uuid)
+		}
+	}
+	if !thread.Complete {
+		t.Error("completed thread not marked complete")
+	}
+	if thread.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want cleared on completion", thread.NextCursor)
+	}
+}
+
+func TestGetThreadStopsWhenCursorRepeats(t *testing.T) {
+	// A reverse-engineered endpoint could return the same cursor forever;
+	// the fetch must terminate with an error rather than spinning, and must
+	// not mark the partially-fetched thread complete.
+	repeating := ThreadDetailResponse{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		Entries:        []ThreadEntry{{UUID: "entry-1"}},
+		HasNextPage:    true,
+		NextCursor:     cursorPtr("cursor-1"),
+	}
+	responses := make([]ThreadDetailResponse, 10)
+	for i := range responses {
+		responses[i] = repeating
+	}
+	getter := &threadGetter{responses: responses}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
+	if err == nil {
+		t.Fatal("GetThread succeeded despite a non-advancing cursor")
+	}
+	if thread != nil {
+		t.Fatalf("GetThread returned a thread: %+v", thread)
+	}
+	if !strings.Contains(err.Error(), "cursor") {
+		t.Errorf("error = %q, want cursor-loop context", err)
+	}
+	// Page 1 (no cursor) + page 2 (cursor-1) is enough to detect the repeat.
+	if getter.calls > 2 {
+		t.Errorf("made %d requests, want stop after detecting the repeat", getter.calls)
+	}
+}
+
 func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
 	getter := &threadGetter{responses: []ThreadDetailResponse{{
 		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
 		Entries:        []ThreadEntry{{UUID: "entry-1"}},
 		HasNextPage:    true,
+		NextCursor:     cursorPtr("cursor-1"),
 	}}}
 
 	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
@@ -104,8 +210,8 @@ func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
 	if thread != nil {
 		t.Fatalf("GetThread returned a partial thread: %+v", thread)
 	}
-	if !strings.Contains(err.Error(), "offset 1") {
-		t.Errorf("error = %q, want offset context", err)
+	if !strings.Contains(err.Error(), "thread-1") {
+		t.Errorf("error = %q, want thread context", err)
 	}
 }
 
@@ -114,6 +220,7 @@ func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
 		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
 		Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
 		HasNextPage:    true,
+		NextCursor:     cursorPtr("cursor-1"),
 	}}}
 
 	var checkpoints []models.Thread
@@ -131,8 +238,8 @@ func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
 	if cp.Complete {
 		t.Error("checkpoint marked complete before the fetch finished")
 	}
-	if cp.NextOffset != 2 {
-		t.Errorf("checkpoint NextOffset = %d, want 2", cp.NextOffset)
+	if cp.NextCursor != "cursor-1" {
+		t.Errorf("checkpoint NextCursor = %q, want cursor-1", cp.NextCursor)
 	}
 	if len(cp.Entries) != 2 {
 		t.Errorf("checkpoint has %d entries, want 2", len(cp.Entries))
@@ -145,16 +252,17 @@ func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
 func TestGetThreadResumesFromCheckpoint(t *testing.T) {
 	getter := &threadGetter{responses: []ThreadDetailResponse{{
 		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
-		// The API recycles results, so entry-2 is served again.
+		// The cursor boundary re-serves entry-2.
 		Entries:     []ThreadEntry{{UUID: "entry-2"}, {UUID: "entry-3"}},
 		HasNextPage: false,
+		NextCursor:  cursorPtr(""),
 	}}}
 
 	resume := &models.Thread{
 		UUID:       "thread-1",
 		Title:      "Long thread",
 		Entries:    []models.Entry{{UUID: "entry-1"}, {UUID: "entry-2"}},
-		NextOffset: 2,
+		NextCursor: "cursor-1",
 	}
 
 	thread, err := GetThread(context.Background(), getter, "thread-1", resume, nil)
@@ -162,10 +270,10 @@ func TestGetThreadResumesFromCheckpoint(t *testing.T) {
 		t.Fatalf("GetThread: %v", err)
 	}
 	if getter.calls != 1 {
-		t.Errorf("made %d requests, want 1 (no refetch from offset 0)", getter.calls)
+		t.Errorf("made %d requests, want 1 (no refetch from the start)", getter.calls)
 	}
-	if !strings.Contains(getter.paths[0], "offset=2") {
-		t.Errorf("first request = %q, want resume at offset=2", getter.paths[0])
+	if !strings.Contains(getter.paths[0], "cursor=cursor-1") {
+		t.Errorf("first request = %q, want resume at cursor-1", getter.paths[0])
 	}
 
 	want := []string{"entry-1", "entry-2", "entry-3"}
@@ -180,116 +288,8 @@ func TestGetThreadResumesFromCheckpoint(t *testing.T) {
 	if !thread.Complete {
 		t.Error("completed thread not marked complete")
 	}
-	if thread.NextOffset != 0 {
-		t.Errorf("NextOffset = %d, want cleared on completion", thread.NextOffset)
-	}
-}
-
-func TestGetThreadStopsWhenPageHasOnlyRecycledEntries(t *testing.T) {
-	// The API can keep reporting HasNextPage while serving only entries
-	// already seen; the fetch must terminate instead of spinning.
-	recycled := ThreadDetailResponse{
-		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
-		Entries:        []ThreadEntry{{UUID: "entry-1"}},
-		HasNextPage:    true,
-	}
-	responses := make([]ThreadDetailResponse, 10)
-	for i := range responses {
-		responses[i] = recycled
-	}
-	getter := &threadGetter{responses: responses}
-
-	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
-	if err != nil {
-		t.Fatalf("GetThread: %v", err)
-	}
-	if len(thread.Entries) != 1 {
-		t.Errorf("got %d entries, want 1 (duplicates dropped)", len(thread.Entries))
-	}
-	if !thread.Complete {
-		t.Error("thread not marked complete")
-	}
-	if getter.calls > maxStalePages+1 {
-		t.Errorf("made %d requests, want stop after %d stale pages", getter.calls, maxStalePages)
-	}
-}
-
-func TestGetThreadContinuesPastOverlappingPage(t *testing.T) {
-	// Pages can overlap, so a page carrying nothing new must not be mistaken
-	// for the end of the thread while later pages still hold new entries.
-	getter := &threadGetter{responses: []ThreadDetailResponse{
-		{
-			ThreadMetadata: ThreadMetadata{Title: "Long thread"},
-			Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
-			HasNextPage:    true,
-		},
-		{
-			Entries:     []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
-			HasNextPage: true,
-		},
-		{
-			Entries:     []ThreadEntry{{UUID: "entry-3"}},
-			HasNextPage: false,
-		},
-	}}
-
-	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
-	if err != nil {
-		t.Fatalf("GetThread: %v", err)
-	}
-
-	want := []string{"entry-1", "entry-2", "entry-3"}
-	if len(thread.Entries) != len(want) {
-		t.Fatalf("got %d entries, want %d: %+v", len(thread.Entries), len(want), thread.Entries)
-	}
-	for i, uuid := range want {
-		if thread.Entries[i].UUID != uuid {
-			t.Errorf("entry %d = %q, want %q", i, thread.Entries[i].UUID, uuid)
-		}
-	}
-	if !thread.Complete {
-		t.Error("thread not marked complete")
-	}
-}
-
-func TestGetThreadRestartsWhenResumeCheckpointIsStale(t *testing.T) {
-	getter := &threadGetter{responses: []ThreadDetailResponse{
-		// Stale offset is past the end of the thread.
-		{},
-		{
-			ThreadMetadata: ThreadMetadata{Title: "Rebuilt thread"},
-			Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
-			HasNextPage:    false,
-		},
-	}}
-
-	resume := &models.Thread{
-		UUID:       "thread-1",
-		Title:      "Stale thread",
-		Entries:    []models.Entry{{UUID: "ghost-1"}},
-		NextOffset: 9000,
-	}
-
-	thread, err := GetThread(context.Background(), getter, "thread-1", resume, nil)
-	if err != nil {
-		t.Fatalf("GetThread: %v", err)
-	}
-	if !strings.Contains(getter.paths[1], "offset=0") {
-		t.Errorf("second request = %q, want restart at offset=0", getter.paths[1])
-	}
-	if len(thread.Entries) != 2 {
-		t.Fatalf("got %d entries, want 2 rebuilt from scratch: %+v", len(thread.Entries), thread.Entries)
-	}
-	for _, e := range thread.Entries {
-		if e.UUID == "ghost-1" {
-			t.Error("stale checkpoint entry retained after restart")
-		}
-	}
-	if thread.Title != "Rebuilt thread" {
-		t.Errorf("Title = %q, want metadata from the restarted fetch", thread.Title)
-	}
-	if !thread.Complete {
-		t.Error("thread not marked complete")
+	if thread.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want cleared on completion", thread.NextCursor)
 	}
 }
 
@@ -298,6 +298,7 @@ func TestGetThreadHonorsCancellation(t *testing.T) {
 		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
 		Entries:        []ThreadEntry{{UUID: "entry-1"}},
 		HasNextPage:    true,
+		NextCursor:     cursorPtr("cursor-1"),
 	}}}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/api/threads_test.go
+++ b/internal/api/threads_test.go
@@ -6,14 +6,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
 type threadGetter struct {
 	responses []ThreadDetailResponse
 	calls     int
+	paths     []string
 }
 
-func (g *threadGetter) Get(_ context.Context, _ string, dst any) error {
+func (g *threadGetter) Get(_ context.Context, path string, dst any) error {
+	g.paths = append(g.paths, path)
 	if g.calls >= len(g.responses) {
 		return errors.New("rate limited")
 	}
@@ -93,7 +97,7 @@ func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
 		HasNextPage:    true,
 	}}}
 
-	thread, err := GetThread(context.Background(), getter, "thread-1")
+	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
 	if err == nil {
 		t.Fatal("GetThread succeeded after a later page failed")
 	}
@@ -102,5 +106,206 @@ func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "offset 1") {
 		t.Errorf("error = %q, want offset context", err)
+	}
+}
+
+func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+		HasNextPage:    true,
+	}}}
+
+	var checkpoints []models.Thread
+	_, err := GetThread(context.Background(), getter, "thread-1", nil, func(t *models.Thread) error {
+		checkpoints = append(checkpoints, *t)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("GetThread succeeded after a later page failed")
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("got %d checkpoints, want 1", len(checkpoints))
+	}
+	cp := checkpoints[0]
+	if cp.Complete {
+		t.Error("checkpoint marked complete before the fetch finished")
+	}
+	if cp.NextOffset != 2 {
+		t.Errorf("checkpoint NextOffset = %d, want 2", cp.NextOffset)
+	}
+	if len(cp.Entries) != 2 {
+		t.Errorf("checkpoint has %d entries, want 2", len(cp.Entries))
+	}
+	if cp.Title != "Long thread" {
+		t.Errorf("checkpoint Title = %q, want metadata preserved", cp.Title)
+	}
+}
+
+func TestGetThreadResumesFromCheckpoint(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		// The API recycles results, so entry-2 is served again.
+		Entries:     []ThreadEntry{{UUID: "entry-2"}, {UUID: "entry-3"}},
+		HasNextPage: false,
+	}}}
+
+	resume := &models.Thread{
+		UUID:       "thread-1",
+		Title:      "Long thread",
+		Entries:    []models.Entry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+		NextOffset: 2,
+	}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", resume, nil)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if getter.calls != 1 {
+		t.Errorf("made %d requests, want 1 (no refetch from offset 0)", getter.calls)
+	}
+	if !strings.Contains(getter.paths[0], "offset=2") {
+		t.Errorf("first request = %q, want resume at offset=2", getter.paths[0])
+	}
+
+	want := []string{"entry-1", "entry-2", "entry-3"}
+	if len(thread.Entries) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(thread.Entries), len(want), thread.Entries)
+	}
+	for i, uuid := range want {
+		if thread.Entries[i].UUID != uuid {
+			t.Errorf("entry %d = %q, want %q", i, thread.Entries[i].UUID, uuid)
+		}
+	}
+	if !thread.Complete {
+		t.Error("completed thread not marked complete")
+	}
+	if thread.NextOffset != 0 {
+		t.Errorf("NextOffset = %d, want cleared on completion", thread.NextOffset)
+	}
+}
+
+func TestGetThreadStopsWhenPageHasOnlyRecycledEntries(t *testing.T) {
+	// The API can keep reporting HasNextPage while serving only entries
+	// already seen; the fetch must terminate instead of spinning.
+	recycled := ThreadDetailResponse{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		Entries:        []ThreadEntry{{UUID: "entry-1"}},
+		HasNextPage:    true,
+	}
+	responses := make([]ThreadDetailResponse, 10)
+	for i := range responses {
+		responses[i] = recycled
+	}
+	getter := &threadGetter{responses: responses}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if len(thread.Entries) != 1 {
+		t.Errorf("got %d entries, want 1 (duplicates dropped)", len(thread.Entries))
+	}
+	if !thread.Complete {
+		t.Error("thread not marked complete")
+	}
+	if getter.calls > maxStalePages+1 {
+		t.Errorf("made %d requests, want stop after %d stale pages", getter.calls, maxStalePages)
+	}
+}
+
+func TestGetThreadContinuesPastOverlappingPage(t *testing.T) {
+	// Pages can overlap, so a page carrying nothing new must not be mistaken
+	// for the end of the thread while later pages still hold new entries.
+	getter := &threadGetter{responses: []ThreadDetailResponse{
+		{
+			ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+			Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+			HasNextPage:    true,
+		},
+		{
+			Entries:     []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+			HasNextPage: true,
+		},
+		{
+			Entries:     []ThreadEntry{{UUID: "entry-3"}},
+			HasNextPage: false,
+		},
+	}}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+
+	want := []string{"entry-1", "entry-2", "entry-3"}
+	if len(thread.Entries) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(thread.Entries), len(want), thread.Entries)
+	}
+	for i, uuid := range want {
+		if thread.Entries[i].UUID != uuid {
+			t.Errorf("entry %d = %q, want %q", i, thread.Entries[i].UUID, uuid)
+		}
+	}
+	if !thread.Complete {
+		t.Error("thread not marked complete")
+	}
+}
+
+func TestGetThreadRestartsWhenResumeCheckpointIsStale(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{
+		// Stale offset is past the end of the thread.
+		{},
+		{
+			ThreadMetadata: ThreadMetadata{Title: "Rebuilt thread"},
+			Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+			HasNextPage:    false,
+		},
+	}}
+
+	resume := &models.Thread{
+		UUID:       "thread-1",
+		Title:      "Stale thread",
+		Entries:    []models.Entry{{UUID: "ghost-1"}},
+		NextOffset: 9000,
+	}
+
+	thread, err := GetThread(context.Background(), getter, "thread-1", resume, nil)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if !strings.Contains(getter.paths[1], "offset=0") {
+		t.Errorf("second request = %q, want restart at offset=0", getter.paths[1])
+	}
+	if len(thread.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2 rebuilt from scratch: %+v", len(thread.Entries), thread.Entries)
+	}
+	for _, e := range thread.Entries {
+		if e.UUID == "ghost-1" {
+			t.Error("stale checkpoint entry retained after restart")
+		}
+	}
+	if thread.Title != "Rebuilt thread" {
+		t.Errorf("Title = %q, want metadata from the restarted fetch", thread.Title)
+	}
+	if !thread.Complete {
+		t.Error("thread not marked complete")
+	}
+}
+
+func TestGetThreadHonorsCancellation(t *testing.T) {
+	getter := &threadGetter{responses: []ThreadDetailResponse{{
+		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
+		Entries:        []ThreadEntry{{UUID: "entry-1"}},
+		HasNextPage:    true,
+	}}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err := GetThread(ctx, getter, "thread-1", nil, func(*models.Thread) error {
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
 	}
 }

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/clappingmonkey/deplexity/internal/client"
@@ -24,11 +25,29 @@ func GetUser(ctx context.Context, c *client.Client) (*models.User, error) {
 }
 
 // ValidateSession checks if the current session is valid by calling the auth endpoint.
+//
+// A hard 401/403 is mapped to client.ErrNotAuthenticated by the HTTP client. A
+// half-valid session can instead return HTTP 200 with an empty user, so an
+// authenticated body with no user identity is treated as unauthenticated too.
 func ValidateSession(ctx context.Context, c *client.Client) (*SessionResponse, error) {
 	var raw SessionResponse
 	path := fmt.Sprintf("/api/auth/session?version=%s&source=default", apiVersion)
 	if err := c.Get(ctx, path, &raw); err != nil {
+		// Preserve the actionable "run 'deplexity login'" message unwrapped.
+		if errors.Is(err, client.ErrNotAuthenticated) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("failed to validate session: %w", err)
 	}
+	if !sessionIsAuthenticated(&raw) {
+		return nil, client.ErrNotAuthenticated
+	}
 	return &raw, nil
+}
+
+// sessionIsAuthenticated reports whether a session response carries a real user
+// identity. A half-valid session can return HTTP 200 with an empty user, which
+// must be treated as unauthenticated.
+func sessionIsAuthenticated(s *SessionResponse) bool {
+	return s != nil && (s.User.ID != "" || s.User.Email != "")
 }

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -1,0 +1,24 @@
+package api
+
+import "testing"
+
+func TestSessionIsAuthenticated(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *SessionResponse
+		want    bool
+	}{
+		{name: "nil session", session: nil, want: false},
+		{name: "empty user", session: &SessionResponse{}, want: false},
+		{name: "user with id", session: &SessionResponse{User: SessionUser{ID: "u-1"}}, want: true},
+		{name: "user with email only", session: &SessionResponse{User: SessionUser{Email: "a@b.com"}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionIsAuthenticated(tt.session); got != tt.want {
+				t.Errorf("sessionIsAuthenticated() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/export/BUILD.bazel
+++ b/internal/export/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
 go_test(
     name = "export_test",
     srcs = [
+        "json_test.go",
         "markdown_test.go",
         "util_test.go",
     ],

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -210,21 +210,44 @@ func (e *JSONExporter) threadDir(thread *models.Thread) string {
 	return filepath.Join(e.OutputDir, "threads", sanitizeFilename(threadSlug(thread)))
 }
 
-// writeJSON writes data as indented JSON to a file.
+// writeJSON writes data as indented JSON to a file atomically.
+//
+// Data is written to a temp file in the same directory and renamed over the
+// target, so a crash mid-write cannot corrupt an existing file. This matters
+// for thread.json, which is rewritten on every pagination checkpoint and must
+// stay a valid resume point even if a later write fails.
 func writeJSON(path string, data interface{}) error {
-	f, err := os.Create(path)
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("could not create %s: %w", path, err)
+		return fmt.Errorf("could not create temp file for %s: %w", path, err)
 	}
-	defer f.Close()
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we return before the rename succeeds.
+	defer func() {
+		if tmpName != "" {
+			_ = os.Remove(tmpName)
+		}
+	}()
 
-	enc := json.NewEncoder(f)
+	enc := json.NewEncoder(tmp)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 
 	if err := enc.Encode(data); err != nil {
+		tmp.Close()
 		return fmt.Errorf("could not write JSON to %s: %w", path, err)
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not flush %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("could not close temp file for %s: %w", path, err)
+	}
 
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("could not replace %s: %w", path, err)
+	}
+	tmpName = "" // rename succeeded; skip cleanup
 	return nil
 }

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -42,11 +42,17 @@ func (e *JSONExporter) LoadThreadIndex() (*models.ThreadIndex, error) {
 	return &index, nil
 }
 
-// ThreadDetailExists checks whether a thread's detail JSON already exists on disk.
-func (e *JSONExporter) ThreadDetailExists(uuid string) bool {
-	path := filepath.Join(e.OutputDir, "threads", sanitizeFilename(uuid), "thread.json")
-	_, err := os.Stat(path)
-	return err == nil
+// LoadCompleteThread reads a thread only when its detail fetch completed.
+// Thread JSON written by earlier versions has no complete field and is retried.
+func (e *JSONExporter) LoadCompleteThread(uuid string) (*models.Thread, error) {
+	thread, err := e.LoadThread(uuid)
+	if err != nil {
+		return nil, err
+	}
+	if !thread.Complete {
+		return nil, fmt.Errorf("thread %s is incomplete", uuid)
+	}
+	return thread, nil
 }
 
 // LoadThread reads a single thread from its JSON file on disk.

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -1,0 +1,50 @@
+package export
+
+import (
+	"testing"
+	"time"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
+
+func TestLoadCompleteThread(t *testing.T) {
+	exporter := &JSONExporter{OutputDir: t.TempDir()}
+	thread := &models.Thread{UUID: "thread-1", Slug: "thread-1"}
+	if err := exporter.ExportThread(thread); err != nil {
+		t.Fatalf("ExportThread: %v", err)
+	}
+
+	if _, err := exporter.LoadCompleteThread(thread.UUID); err == nil {
+		t.Fatal("LoadCompleteThread succeeded for an incomplete thread")
+	}
+
+	thread.Complete = true
+	if err := exporter.ExportThread(thread); err != nil {
+		t.Fatalf("ExportThread: %v", err)
+	}
+
+	loaded, err := exporter.LoadCompleteThread(thread.UUID)
+	if err != nil {
+		t.Fatalf("LoadCompleteThread: %v", err)
+	}
+	if !loaded.Complete {
+		t.Fatal("loaded thread is not complete")
+	}
+}
+
+func TestLoadCompleteThreadPreservesMetadata(t *testing.T) {
+	exporter := &JSONExporter{OutputDir: t.TempDir()}
+	updatedAt := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	thread := &models.Thread{UUID: "thread-1", Slug: "thread-1", UpdatedAt: updatedAt, Complete: true}
+	if err := exporter.ExportThread(thread); err != nil {
+		t.Fatalf("ExportThread: %v", err)
+	}
+
+	loaded, err := exporter.LoadCompleteThread(thread.UUID)
+	if err != nil {
+		t.Fatalf("LoadCompleteThread: %v", err)
+	}
+	if !loaded.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", loaded.UpdatedAt, updatedAt)
+	}
+}

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -1,6 +1,8 @@
 package export
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -46,5 +48,43 @@ func TestLoadCompleteThreadPreservesMetadata(t *testing.T) {
 	}
 	if !loaded.UpdatedAt.Equal(updatedAt) {
 		t.Errorf("UpdatedAt = %v, want %v", loaded.UpdatedAt, updatedAt)
+	}
+}
+
+func TestWriteJSONFailedWriteLeavesExistingFileIntact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thread.json")
+
+	if err := writeJSON(path, map[string]string{"state": "good"}); err != nil {
+		t.Fatalf("writeJSON (initial): %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read initial file: %v", err)
+	}
+
+	// A channel cannot be JSON-encoded, so Encode fails after the temp file
+	// is created but before the rename. The original file must survive.
+	if err := writeJSON(path, make(chan int)); err == nil {
+		t.Fatal("writeJSON succeeded encoding an unserializable value")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("original file missing after failed write: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("original file changed after failed write:\n before=%s\n after=%s", before, after)
+	}
+
+	// No temp files should be left behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "thread.json" {
+			t.Errorf("leftover file after failed write: %s", e.Name())
+		}
 	}
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -22,6 +22,9 @@ type Thread struct {
 	Entries    []Entry   `json:"entries,omitempty"`
 	Bookmarked bool      `json:"bookmarked,omitempty"`
 	Complete   bool      `json:"complete"`
+	// NextOffset is the pagination offset to resume from when Complete is
+	// false. Entries before it have already been persisted.
+	NextOffset int `json:"next_offset,omitempty"`
 }
 
 // Entry represents a single query-response pair within a thread.

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -21,6 +21,7 @@ type Thread struct {
 	SpaceUUID  string    `json:"space_uuid,omitempty"`
 	Entries    []Entry   `json:"entries,omitempty"`
 	Bookmarked bool      `json:"bookmarked,omitempty"`
+	Complete   bool      `json:"complete"`
 }
 
 // Entry represents a single query-response pair within a thread.
@@ -44,15 +45,15 @@ type Source struct {
 
 // Space represents a Perplexity Space (collection).
 type Space struct {
-	UUID         string    `json:"uuid"`
-	Name         string    `json:"name"`
-	Slug         string    `json:"slug,omitempty"`
-	Emoji        string    `json:"emoji,omitempty"`
-	Description  string    `json:"description,omitempty"`
-	Instructions string    `json:"instructions,omitempty"`
+	UUID         string     `json:"uuid"`
+	Name         string     `json:"name"`
+	Slug         string     `json:"slug,omitempty"`
+	Emoji        string     `json:"emoji,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	Instructions string     `json:"instructions,omitempty"`
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
-	UpdatedAt    time.Time `json:"updated_at"`
-	ThreadUUIDs  []string  `json:"thread_uuids,omitempty"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	ThreadUUIDs  []string   `json:"thread_uuids,omitempty"`
 }
 
 // ExportManifest holds metadata about an export run.
@@ -80,11 +81,13 @@ type ThreadIndex struct {
 	Complete  bool        `json:"complete"` // false if listing was interrupted
 }
 
-// ThreadRef is a lightweight reference to a thread (UUID + title only).
+// ThreadRef is a lightweight reference to a thread from the list endpoint.
 type ThreadRef struct {
-	UUID      string `json:"uuid"`
-	Title     string `json:"title"`
-	SpaceUUID string `json:"space_uuid,omitempty"`
+	UUID              string    `json:"uuid"`
+	Title             string    `json:"title"`
+	SpaceUUID         string    `json:"space_uuid,omitempty"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	PreviousUpdatedAt time.Time `json:"-"`
 }
 
 // SavedSession represents the persisted authentication session.

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -22,9 +22,9 @@ type Thread struct {
 	Entries    []Entry   `json:"entries,omitempty"`
 	Bookmarked bool      `json:"bookmarked,omitempty"`
 	Complete   bool      `json:"complete"`
-	// NextOffset is the pagination offset to resume from when Complete is
-	// false. Entries before it have already been persisted.
-	NextOffset int `json:"next_offset,omitempty"`
+	// NextCursor is the pagination cursor to resume from when Complete is
+	// false. The entries already fetched are persisted alongside it.
+	NextCursor string `json:"next_cursor,omitempty"`
 }
 
 // Entry represents a single query-response pair within a thread.


### PR DESCRIPTION
#### Description

Fixes long-thread export failures reported in #45, plus a session/caching bug found during live testing of that fix.

**1. Cursor pagination for thread detail (`d724850`) — root cause of #45.**
The thread-detail endpoint (`GET /rest/thread/{uuid}`) ignores the `offset` parameter and paginates by an opaque `cursor` instead. The old offset-based loop therefore re-requested the same first page; on long threads this combined with 429 rate limiting to truncate entries, yet the thread was still written as `Complete`. Detail pagination now seeds from `resume.NextCursor`, dedupes by entry UUID, and terminates only on `!HasNextPage || NextCursor == ""`. A repeated non-advancing cursor is treated as an API pagination loop and returns an error that preserves the last checkpoint instead of silently truncating. `limit` raised 50 → 100 (endpoint honors it live). `ThreadIndex.NextOffset` → `NextCursor`. `writeJSON` is now atomic (temp file + fsync + rename) so an interrupted write can't corrupt `thread_index.json`.

**2. Session validation + empty-index cache hardening (`3679eac`) — bug found live.**
A half-valid session made `list_ask_threads` return HTTP 200 with an empty array and no error. That empty result was marked `Complete` and cached; the 24h cache gate then served it on every non-refresh run, so the export reported zero threads for a day. The profile 401 that would reveal the bad session only fired *after* the index was written.

- `ExportCmd.Run` now calls `api.ValidateSession` up front, before any list/index phase, so an invalid session aborts before writing anything and surfaces the "run 'deplexity login'" message immediately.
- `ValidateSession` treats a 200 response with an empty user (no id and no email) as unauthenticated, catching the soft-fail the list endpoint exhibits; the actionable auth error is returned unwrapped.
- `finalizeIndex` marks an index `Complete` only when it holds threads, so a spurious empty listing is never cached as complete.
- `indexServableFromCache` requires `Total > 0`, so an already-poisoned `Complete`-but-empty index is not served and is healed by a re-list on the next run without needing `--refresh`.

Commits `f242f7a` / `0e73540` were earlier offset-era resume fixes, superseded by the cursor work in `d724850`.

**Motivation/Context:** #45 — long threads hitting 429 during paginated detail fetch were wrongly saved as complete despite truncation. Investigation showed the detail endpoint paginates by cursor, not offset, so the offset loop never advanced. Fixing that surfaced a second, independent bug where a soft-failed session poisoned the thread-index cache for 24h.

**Tests Executed:**
- `bazel test //...` — all 5 targets pass (api, client, export, auth, cmd/deplexity), including new tests: `TestGetThreadPaginatesByCursor`, `TestGetThreadStopsWhenCursorRepeats`, `TestThreadPagePathEscapesCursor`, `TestThreadPagePathOmitsEmptyCursor`, `TestWriteJSONFailedWriteLeavesExistingFileIntact`, `TestFinalizeIndex`, `TestSessionIsAuthenticated`, `TestIndexServableFromCache`.
- Live `--refresh` export: 166 threads indexed + all details fetched via cursor pagination in ~1m36s.
- Live non-refresh export: valid 166-thread cache served correctly; poisoned empty-complete cache confirmed no longer served (heals via re-list).

---

#### Checklist

 * [ ] Change was tested in staging environment successfully
 * [ ] Change has been documented
 * [x] I have commented my code, particularly in hard-to-understand areas
 * [x] I have added tests that prove my fix is effective or that my feature works

---

#### General PR information (references)

Issue: #45
Depends-On: N/A
