### PR TITLE
feat: export space instructions and attached skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,11 @@ Binary entrypoint: `cmd/deplexity/main.go`. Version/buildTime stamped via `x_def
 - `internal/api/user.go` — `GetUser` via `GET /api/user`.
 - `internal/models/models.go` — clean domain models used throughout the app (decoupled from API shape).
 - `internal/auth/` — browser-based login via `go-rod/rod` (visible Chrome), cookie capture, session persistence. Also supports `--cookie` for manual token auth.
-- `internal/client/client.go` — authenticated `net/http` client with raw `Cookie` header, adaptive rate limiting, separate HTTP (429/5xx) and network (DNS/dial/TLS) retry loops. All methods accept `context.Context`.
+- `internal/client/client.go` — authenticated `net/http` client with raw `Cookie` header, adaptive rate limiting, separate HTTP (429/5xx) and network (DNS/dial/TLS) retry loops. All methods accept `context.Context`. Also provides `GetRawURL` for fetching absolute third-party URLs (pre-signed S3 skill bodies) *without* the session cookie/Origin/`x-app-*` headers; it validates the target is `https` with a non-empty host and caps the body at 10 MB (`io.LimitReader`, errors on overflow rather than truncating).
 - `internal/client/transport.go` — Chrome TLS fingerprint via `refraction-networking/utls` to bypass Cloudflare.
 - `internal/client/ratelimit.go` — `RetryWithBackoff`, `computeBackoff`, shared retry constants.
 - `internal/export/` — JSON, Markdown, and PDF exporters. PDF uses `gpdf` (pure Go, zero dependencies). JSON exporter handles `thread_index.json` persistence for resumable exports. All exporters copy thread files into space folders for self-contained output.
-- `internal/export/util.go` — shared helpers: `sanitizeFilename`, `threadSlug`.
+- `internal/export/util.go` — shared helpers: `sanitizeFilename`, `threadSlug`, and `skillFilenames`/`shortID` (collision-free `.md` filenames for a space's skills, disambiguated by a short skill-ID suffix; used by both the JSON and Markdown exporters so their sidecar paths and links agree).
 - CLI framework: `alecthomas/kong` (struct-tag based). Commands defined as types with `Run(ctx context.Context) error` methods in `main.go`.
 
 ## Browser Dependency
@@ -95,6 +95,7 @@ Use `--refresh` to force re-fetching the thread index.
 - Cloudflare blocks HTML page fetching even with valid cookies, but `/rest/` API endpoints work fine.
 - `deplexity login` must be run before `export` — there is no inline auth flow. Alternatively, use `deplexity login --cookie <TOKEN>` for headless/server environments.
 - Raw `Cookie` header is used instead of `http.CookieJar`/`AddCookie` to avoid Go's cookie domain validation issues.
+- `sanitizeFilename` lowercases names, so on-disk space/skill paths are lowercase (e.g. a "Recipes" space → `spaces/recipes/`, its skills → `spaces/recipes/skills/<name>.md`). Tests asserting these paths must derive them via `sanitizeFilename` (or use the lowercase form) rather than hardcoding the display name — a hardcoded `"Recipes"` passes on case-insensitive macOS but fails on case-sensitive Linux (CI).
 - Signal handling: first Ctrl+C cancels the context (graceful stop after current operation), second Ctrl+C force-exits via default OS handler. Implemented via `signal.NotifyContext` + dedicated `signal.Notify` channel (avoids spurious message on normal exit).
 - PDF sources rendered as numbered list `"N. Title (domain)"` — avoids gpdf hang on long unbreakable URLs (S3 pre-signed URLs up to 1600 chars). Previous table layout caused infinite loops in gpdf's word-wrap.
 - Multi-threaded PDF export: `--pdf-workers` flag (default: `runtime.NumCPU()`). Each worker creates its own `gpdf.Document` so no locking needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Binary entrypoint: `cmd/deplexity/main.go`. Version/buildTime stamped via `x_def
 
 - `internal/api/types.go` — **raw API response structs** (JSON tags match Perplexity's undocumented internal API, verified against live responses May 2026, API v2.18).
 - `internal/api/threads.go` — `ListThreads`, `ListThreadsFrom` (POST `list_ask_threads` with pagination, dual stop condition), `GetThread`.
-- `internal/api/collections.go` — `ListCollections` via `GET /rest/spaces`.
+- `internal/api/collections.go` — `ListCollections` via `GET /rest/spaces`, then always-on fail-soft enrichment: `GetCollection` (per-space instructions/description/suggested_queries/primers) and `ListSpaceSkills`/`GetSkillDetail` (collection-scoped skills + SKILL.md body).
 - `internal/api/user.go` — `GetUser` via `GET /api/user`.
 - `internal/models/models.go` — clean domain models used throughout the app (decoupled from API shape).
 - `internal/auth/` — browser-based login via `go-rod/rod` (visible Chrome), cookie capture, session persistence. Also supports `--cookie` for manual token auth.
@@ -65,7 +65,10 @@ All endpoints are reverse-engineered from browser DevTools (May 2026, API versio
 |--------|----------|---------|
 | POST | `/rest/thread/list_ask_threads` | All threads with pagination (body: `{limit, offset, ascending, ...}`) |
 | GET | `/rest/thread/{uuid}?with_schematized_response=true` | Thread detail with full entries |
-| GET | `/rest/spaces` | All spaces (private/shared/invited/org/saved) |
+| GET | `/rest/spaces` | All spaces (private/shared/invited/org/saved) — list only, omits instructions/skills |
+| GET | `/rest/collections/get_collection?collection_slug={slug}` | Per-space detail: instructions, description, suggested_queries, primers (param must be `collection_slug`; `collection_uuid` → 422) |
+| GET | `/rest/skills/selectable?collection_uuid={uuid}` | Skills selectable in a space; space-attached skills have `scope=="collection"` (vs `global`) |
+| GET | `/rest/skills/{id}?view_scope=individual` | Skill detail incl. pre-signed S3 `file_url` for the SKILL.md body |
 | GET | `/api/user` | User profile |
 | GET | `/api/auth/session` | Session info + expiry |
 | GET | `/rest/user/settings` | Limits, quotas, connector config |

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ deplexity-export/
 │   ├── index.json
 │   ├── spaces.md
 │   └── <space-name>/
-│       ├── space.json
+│       ├── space.json         # Incl. AI instructions, suggested queries, primers, skills metadata
+│       ├── skills/            # Attached skills' SKILL.md bodies (referenced by space.json)
+│       │   └── <skill-name>.md
 │       └── threads/           # Self-contained copies of this space's threads
 │           └── <thread-slug>/
 │               ├── thread.json
@@ -147,6 +149,8 @@ deplexity-export/
 ```
 
 Each space folder is self-contained — you can ZIP and share a single space without needing the top-level `threads/` directory.
+
+Space exports capture each space's full context: its custom AI instructions, description, suggested queries, primers, and any attached skills. Skill definitions are written as `SKILL.md` files under `spaces/<space-name>/skills/` and referenced from `space.json`.
 
 ---
 
@@ -232,8 +236,8 @@ Key design decisions:
 
 - Session tokens are stored with `0600` permissions in `~/.config/deplexity/`
 - No credentials are ever logged or transmitted to third parties
-- The tool only communicates with `perplexity.ai`
-- All HTTP requests use the same TLS fingerprint and headers as a real Chrome session
+- Requests to Perplexity use the same TLS fingerprint and headers as a real Chrome session
+- Skill bodies are downloaded from the pre-signed storage URLs (Amazon S3) that Perplexity returns; these fetches deliberately carry **no** session cookie or Perplexity headers, so your credentials are never sent off-platform
 
 ---
 

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -130,6 +131,11 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 		fmt.Print("Fetching spaces...")
 		spaces, err = api.ListCollections(ctx, c)
 		if err != nil {
+			// Cancellation must abort the whole export, not be swallowed as a
+			// skipped section.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
 			fmt.Fprintf(os.Stderr, " skipped (%v)\n", err)
 			spaces = nil
 		} else {

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
 go_test(
     name = "api_test",
     srcs = [
+        "collections_test.go",
         "threads_test.go",
         "user_test.go",
     ],

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -48,8 +48,6 @@ func ListCollections(ctx context.Context, c *client.Client) ([]models.Space, err
 		return nil, fmt.Errorf("failed to list spaces: %w", err)
 	}
 
-	var spaces []models.Space
-
 	// Combine all space categories into a single list.
 	allItems := make([]SpaceItem, 0)
 	allItems = append(allItems, raw.PrivateSpaces...)
@@ -58,7 +56,24 @@ func ListCollections(ctx context.Context, c *client.Client) ([]models.Space, err
 	allItems = append(allItems, raw.SavedSpaces...)
 	allItems = append(allItems, raw.OrganizationSpaces...)
 
-	for _, item := range allItems {
+	return enrichSpaces(ctx, c, allItems)
+}
+
+// enrichSpaces converts raw space list items into domain models and enriches
+// each with per-space detail and collection-scoped skills.
+//
+// Enrichment is best-effort: a failure to enrich one space (or one of its
+// skills) is logged and skipped rather than aborting the whole export, so a
+// single broken space never loses the rest of the data. Context cancellation
+// is the sole exception — it aborts immediately and propagates the error so an
+// interrupted export is not mistaken for a partial success.
+//
+// It is separated from ListCollections so the fail-soft/cancellation contract
+// can be exercised against a mock enricher without a live client.
+func enrichSpaces(ctx context.Context, c enricher, items []SpaceItem) ([]models.Space, error) {
+	var spaces []models.Space
+
+	for _, item := range items {
 		space := models.Space{
 			UUID:      item.UUID,
 			Name:      item.Title,
@@ -161,6 +176,11 @@ func GetSkillDetail(ctx context.Context, c getter, skillID string) (*SkillDetail
 
 // enrichSpaceDetail populates a space with detail from get_collection.
 func enrichSpaceDetail(ctx context.Context, c getter, space *models.Space) error {
+	// get_collection is keyed by slug; without one there is nothing to fetch.
+	if space.Slug == "" {
+		return nil
+	}
+
 	detail, err := GetCollection(ctx, c, space.Slug)
 	if err != nil {
 		return err
@@ -200,6 +220,12 @@ func enrichSpaceDetail(ctx context.Context, c getter, space *models.Space) error
 // skills available to the space are intentionally excluded for now; see the
 // follow-up noted in TODO.md.
 func enrichSpaceSkills(ctx context.Context, c enricher, space *models.Space) error {
+	// skills/selectable is keyed by collection UUID; without one there is
+	// nothing to fetch.
+	if space.UUID == "" {
+		return nil
+	}
+
 	summaries, err := ListSpaceSkills(ctx, c, space.UUID)
 	if err != nil {
 		return err

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -2,13 +2,45 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
+	"net/url"
 
 	"github.com/clappingmonkey/deplexity/internal/client"
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
-// ListCollections fetches all user spaces/collections via GET /rest/spaces.
+// isCancellation reports whether err was caused by context cancellation or
+// deadline expiry, which must abort enrichment rather than be logged and
+// skipped like ordinary fail-soft errors.
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// rawGetter fetches an absolute URL and returns the raw body. It is satisfied
+// by *client.Client via GetRawURL and is used to download skill bodies from
+// short-lived pre-signed URLs.
+type rawGetter interface {
+	GetRawURL(context.Context, string) ([]byte, error)
+}
+
+// enricher is the client capability set needed to enrich spaces: JSON GETs for
+// detail/skill endpoints plus raw fetches for skill bodies.
+type enricher interface {
+	getter
+	rawGetter
+}
+
+// ListCollections fetches all user spaces/collections via GET /rest/spaces and
+// enriches each with per-space detail (instructions, description, suggested
+// queries, primers) and attached skills.
+//
+// The list endpoint omits all per-space configuration, so each space is
+// enriched with a GET /rest/collections/get_collection call and its
+// collection-scoped skills. Enrichment is best-effort: a failure to enrich one
+// space (or one of its skills) is logged and skipped rather than aborting the
+// whole export, so a single broken space never loses the rest of the data.
 func ListCollections(ctx context.Context, c *client.Client) ([]models.Space, error) {
 	var raw SpacesResponse
 	path := fmt.Sprintf("/rest/spaces?version=%s&source=default", apiVersion)
@@ -27,14 +59,195 @@ func ListCollections(ctx context.Context, c *client.Client) ([]models.Space, err
 	allItems = append(allItems, raw.OrganizationSpaces...)
 
 	for _, item := range allItems {
-		spaces = append(spaces, models.Space{
+		space := models.Space{
 			UUID:      item.UUID,
 			Name:      item.Title,
 			Slug:      item.Slug,
 			Emoji:     item.Emoji,
 			UpdatedAt: parseTime(item.Updated),
-		})
+		}
+
+		// Enrich with per-space detail (fail-soft).
+		if err := enrichSpaceDetail(ctx, c, &space); err != nil {
+			// Context cancellation should propagate; other errors are skipped.
+			if isCancellation(err) {
+				return nil, err
+			}
+			log.Printf("warning: could not fetch details for space %q (%s): %v", space.Name, space.Slug, err)
+		}
+
+		// Enrich with collection-scoped skills (fail-soft).
+		if err := enrichSpaceSkills(ctx, c, &space); err != nil {
+			if isCancellation(err) {
+				return nil, err
+			}
+			log.Printf("warning: could not fetch skills for space %q (%s): %v", space.Name, space.Slug, err)
+		}
+
+		spaces = append(spaces, space)
 	}
 
 	return spaces, nil
+}
+
+// GetCollection fetches per-space detail via GET /rest/collections/get_collection.
+//
+// The endpoint requires collection_slug — passing collection_uuid returns 422.
+func GetCollection(ctx context.Context, c getter, slug string) (*CollectionDetailResponse, error) {
+	var detail CollectionDetailResponse
+	path := fmt.Sprintf(
+		"/rest/collections/get_collection?collection_slug=%s&version=%s&source=default",
+		url.QueryEscape(slug), apiVersion,
+	)
+	if err := c.Get(ctx, path, &detail); err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+// ListSpaceSkills fetches the skills selectable within a space via
+// GET /rest/skills/selectable?collection_uuid={uuid}, following next_cursor
+// pagination so that spaces with many skills are fully captured.
+func ListSpaceSkills(ctx context.Context, c getter, collectionUUID string) ([]SkillSummary, error) {
+	var all []SkillSummary
+	cursor := ""
+
+	// Guard against a non-advancing cursor from the reverse-engineered API.
+	seenCursors := map[string]bool{}
+
+	for {
+		path := fmt.Sprintf(
+			"/rest/skills/selectable?collection_uuid=%s&version=%s&source=default",
+			url.QueryEscape(collectionUUID), apiVersion,
+		)
+		if cursor != "" {
+			path += "&cursor=" + url.QueryEscape(cursor)
+		}
+
+		var resp SkillsSelectableResponse
+		if err := c.Get(ctx, path, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Skills...)
+
+		if resp.NextCursor == nil || *resp.NextCursor == "" {
+			break
+		}
+		if seenCursors[*resp.NextCursor] {
+			// The cursor is repeating; stop rather than loop forever.
+			log.Printf("warning: skills pagination cursor repeated for space %s; stopping", collectionUUID)
+			break
+		}
+		seenCursors[*resp.NextCursor] = true
+		cursor = *resp.NextCursor
+	}
+
+	return all, nil
+}
+
+// GetSkillDetail fetches full skill detail via GET /rest/skills/{id}. The
+// returned Skill.FileURL is a short-lived pre-signed URL for the SKILL.md body.
+func GetSkillDetail(ctx context.Context, c getter, skillID string) (*SkillDetailResponse, error) {
+	var detail SkillDetailResponse
+	path := fmt.Sprintf(
+		"/rest/skills/%s?view_scope=individual&version=%s&source=default",
+		url.PathEscape(skillID), apiVersion,
+	)
+	if err := c.Get(ctx, path, &detail); err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+// enrichSpaceDetail populates a space with detail from get_collection.
+func enrichSpaceDetail(ctx context.Context, c getter, space *models.Space) error {
+	detail, err := GetCollection(ctx, c, space.Slug)
+	if err != nil {
+		return err
+	}
+
+	space.Description = detail.Description
+	space.Instructions = detail.Instructions
+	space.URL = detail.URL
+	space.KnowledgeDreamInstructions = detail.KnowledgeDreamInstructions
+	space.ProjectStatusSummaryInstruction = detail.ProjectStatusSummaryInstruction
+	space.FocusedWebConfig = detail.FocusedWebConfig
+	space.MemoryMode = detail.MemoryMode
+	space.Access = detail.Access
+	space.UserPermission = detail.UserPermission
+	space.ThreadCount = detail.ThreadCount
+	space.PageCount = detail.PageCount
+	space.FileCount = detail.FileCount
+
+	for _, sq := range detail.SuggestedQueries {
+		space.SuggestedQueries = append(space.SuggestedQueries, sq.Query)
+	}
+	for _, p := range detail.Primers {
+		space.Primers = append(space.Primers, models.Primer{
+			PrimerType: p.PrimerType,
+			Queries:    p.Queries,
+		})
+	}
+
+	return nil
+}
+
+// enrichSpaceSkills populates a space with its collection-scoped skills,
+// including each skill's SKILL.md body. Per-skill failures are logged and
+// skipped so one bad skill does not drop the others.
+//
+// Only skills with scope=="collection" (space-specific) are exported. Global
+// skills available to the space are intentionally excluded for now; see the
+// follow-up noted in TODO.md.
+func enrichSpaceSkills(ctx context.Context, c enricher, space *models.Space) error {
+	summaries, err := ListSpaceSkills(ctx, c, space.UUID)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range summaries {
+		if s.Scope != "collection" {
+			continue
+		}
+
+		skill := models.Skill{
+			ID:          s.ID,
+			Name:        s.Name,
+			Description: s.Description,
+			Scope:       s.Scope,
+		}
+
+		// Fetch full detail (metadata + pre-signed body URL).
+		detail, err := GetSkillDetail(ctx, c, s.ID)
+		if err != nil {
+			if isCancellation(err) {
+				return err
+			}
+			log.Printf("warning: could not fetch detail for skill %q in space %q: %v", s.Name, space.Name, err)
+			space.Skills = append(space.Skills, skill)
+			continue
+		}
+
+		skill.Categories = detail.Skill.Categories
+		skill.Tags = detail.Skill.Tags
+		skill.CreatedAt = detail.Skill.CreatedAt
+		skill.UpdatedAt = detail.Skill.UpdatedAt
+
+		// Download the SKILL.md body now — the URL is short-lived (~15 min).
+		if detail.Skill.FileURL != "" {
+			body, err := c.GetRawURL(ctx, detail.Skill.FileURL)
+			if err != nil {
+				if isCancellation(err) {
+					return err
+				}
+				log.Printf("warning: could not download body for skill %q in space %q: %v", s.Name, space.Name, err)
+			} else {
+				skill.Body = string(body)
+			}
+		}
+
+		space.Skills = append(space.Skills, skill)
+	}
+
+	return nil
 }

--- a/internal/api/collections_test.go
+++ b/internal/api/collections_test.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
+
+// mockEnricher is a test double for the enricher interface. It routes GET
+// requests to canned JSON responses keyed by a substring of the request path,
+// and serves raw URL fetches from a map keyed by URL.
+type mockEnricher struct {
+	// responses maps a path substring to a JSON body to unmarshal into dest.
+	responses map[string]string
+	// rawBodies maps an absolute URL to its raw body.
+	rawBodies map[string]string
+	// getErr, if set for a matching path substring, is returned instead.
+	getErrs map[string]error
+	// rawErrs, if set for a matching URL, is returned instead.
+	rawErrs map[string]error
+
+	paths   []string
+	rawURLs []string
+}
+
+func (m *mockEnricher) Get(_ context.Context, path string, dest any) error {
+	m.paths = append(m.paths, path)
+	for sub, err := range m.getErrs {
+		if strings.Contains(path, sub) {
+			return err
+		}
+	}
+	for sub, body := range m.responses {
+		if strings.Contains(path, sub) {
+			return json.Unmarshal([]byte(body), dest)
+		}
+	}
+	return errors.New("no canned response for path: " + path)
+}
+
+func (m *mockEnricher) GetRawURL(_ context.Context, rawURL string) ([]byte, error) {
+	m.rawURLs = append(m.rawURLs, rawURL)
+	if err, ok := m.rawErrs[rawURL]; ok {
+		return nil, err
+	}
+	if body, ok := m.rawBodies[rawURL]; ok {
+		return []byte(body), nil
+	}
+	return nil, errors.New("no canned body for url: " + rawURL)
+}
+
+func TestGetCollectionUsesSlugParam(t *testing.T) {
+	m := &mockEnricher{responses: map[string]string{
+		"get_collection": `{"uuid":"u1","instructions":"Test for the deplexity tool","description":"desc"}`,
+	}}
+
+	detail, err := GetCollection(context.Background(), m, "recipes-55F50RUIQUK_fqfJUieN1w")
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if detail.Instructions != "Test for the deplexity tool" {
+		t.Errorf("Instructions = %q, want sentinel", detail.Instructions)
+	}
+	if len(m.paths) != 1 {
+		t.Fatalf("made %d requests, want 1", len(m.paths))
+	}
+	// The endpoint must be queried by collection_slug (collection_uuid → 422).
+	if !strings.Contains(m.paths[0], "collection_slug=recipes-55F50RUIQUK_fqfJUieN1w") {
+		t.Errorf("path = %q, want collection_slug param", m.paths[0])
+	}
+	if strings.Contains(m.paths[0], "collection_uuid=") {
+		t.Errorf("path = %q, must not use collection_uuid", m.paths[0])
+	}
+}
+
+func TestEnrichSpaceDetailMapsFields(t *testing.T) {
+	body := `{
+		"uuid":"u1",
+		"description":"A cooking space",
+		"instructions":"Test for the deplexity tool",
+		"url":"https://www.perplexity.ai/spaces/recipes",
+		"suggested_queries":[{"query":"How do I sear steak?"},{"query":"Substitute for butter"}],
+		"primers":[{"primer_type":"welcome","queries":["hi","hello"]}],
+		"thread_count":5,"page_count":2,"file_count":1,
+		"memory_mode":"auto"
+	}`
+	m := &mockEnricher{responses: map[string]string{"get_collection": body}}
+
+	space := &models.Space{UUID: "u1", Slug: "recipes-x"}
+	if err := enrichSpaceDetail(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceDetail: %v", err)
+	}
+
+	if space.Instructions != "Test for the deplexity tool" {
+		t.Errorf("Instructions = %q", space.Instructions)
+	}
+	if space.Description != "A cooking space" {
+		t.Errorf("Description = %q", space.Description)
+	}
+	wantQueries := []string{"How do I sear steak?", "Substitute for butter"}
+	if len(space.SuggestedQueries) != len(wantQueries) {
+		t.Fatalf("SuggestedQueries = %v, want %v", space.SuggestedQueries, wantQueries)
+	}
+	for i, q := range wantQueries {
+		if space.SuggestedQueries[i] != q {
+			t.Errorf("SuggestedQueries[%d] = %q, want %q", i, space.SuggestedQueries[i], q)
+		}
+	}
+	if len(space.Primers) != 1 || space.Primers[0].PrimerType != "welcome" {
+		t.Fatalf("Primers = %+v, want one welcome primer", space.Primers)
+	}
+	if len(space.Primers[0].Queries) != 2 {
+		t.Errorf("Primer queries = %v, want 2", space.Primers[0].Queries)
+	}
+	if space.ThreadCount != 5 || space.PageCount != 2 || space.FileCount != 1 {
+		t.Errorf("counts = %d/%d/%d, want 5/2/1", space.ThreadCount, space.PageCount, space.FileCount)
+	}
+	if space.MemoryMode != "auto" {
+		t.Errorf("MemoryMode = %q, want auto", space.MemoryMode)
+	}
+}
+
+func TestEnrichSpaceSkillsFiltersCollectionScopeAndFetchesBody(t *testing.T) {
+	// selectable returns one collection-scoped skill and one global skill;
+	// only the collection-scoped one must be exported.
+	selectable := `{"skills":[
+		{"id":"skill-collection","name":"git-commit","description":"Commit helper","scope":"collection"},
+		{"id":"skill-global","name":"create-skill","description":"Global helper","scope":"global"}
+	],"next_cursor":null}`
+	detail := `{"is_owner":false,"is_creator":true,"enabled":true,"installed":true,"skill":{
+		"id":"skill-collection","name":"git-commit","description":"Commit helper","scope":"collection",
+		"file_url":"https://s3.example.com/git-commit/SKILL.md?sig=abc",
+		"categories":["dev"],"tags":{"hide_from_index":"false"},
+		"created_at":"2026-08-29T12:11:27.702265","updated_at":"2026-08-29T12:11:27.865141"
+	}}`
+	m := &mockEnricher{
+		responses: map[string]string{
+			"selectable":      selectable,
+			"skills/skill-collection": detail,
+		},
+		rawBodies: map[string]string{
+			"https://s3.example.com/git-commit/SKILL.md?sig=abc": "---\nname: git-commit\n---\nbody",
+		},
+	}
+
+	space := &models.Space{UUID: "u1", Name: "Recipes"}
+	if err := enrichSpaceSkills(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceSkills: %v", err)
+	}
+
+	if len(space.Skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (collection-scoped only)", len(space.Skills))
+	}
+	sk := space.Skills[0]
+	if sk.ID != "skill-collection" || sk.Name != "git-commit" {
+		t.Errorf("skill = %+v, want git-commit collection skill", sk)
+	}
+	if sk.Scope != "collection" {
+		t.Errorf("scope = %q, want collection", sk.Scope)
+	}
+	if sk.Body != "---\nname: git-commit\n---\nbody" {
+		t.Errorf("body = %q, want fetched SKILL.md", sk.Body)
+	}
+	if len(sk.Categories) != 1 || sk.Categories[0] != "dev" {
+		t.Errorf("categories = %v, want [dev]", sk.Categories)
+	}
+	if sk.Tags["hide_from_index"] != "false" {
+		t.Errorf("tags = %v, want hide_from_index=false", sk.Tags)
+	}
+}
+
+func TestEnrichSpaceSkillsFailSoftOnBodyDownload(t *testing.T) {
+	selectable := `{"skills":[
+		{"id":"skill-collection","name":"git-commit","description":"Commit helper","scope":"collection"}
+	],"next_cursor":null}`
+	detail := `{"skill":{"id":"skill-collection","name":"git-commit","scope":"collection",
+		"file_url":"https://s3.example.com/broken/SKILL.md"}}`
+	m := &mockEnricher{
+		responses: map[string]string{
+			"selectable":              selectable,
+			"skills/skill-collection": detail,
+		},
+		rawErrs: map[string]error{
+			"https://s3.example.com/broken/SKILL.md": errors.New("403 expired"),
+		},
+	}
+
+	space := &models.Space{UUID: "u1", Name: "Recipes"}
+	if err := enrichSpaceSkills(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceSkills should be fail-soft on body error, got: %v", err)
+	}
+	// The skill is still exported as metadata, just without a body.
+	if len(space.Skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (metadata retained)", len(space.Skills))
+	}
+	if space.Skills[0].Body != "" {
+		t.Errorf("body = %q, want empty after failed download", space.Skills[0].Body)
+	}
+}
+
+func TestEnrichSpaceSkillsFailSoftOnDetailError(t *testing.T) {
+	// A non-cancellation error fetching skill detail must not abort the whole
+	// enrichment: the skill is retained as metadata-only from the summary.
+	selectable := `{"skills":[
+		{"id":"skill-collection","name":"git-commit","description":"Commit helper","scope":"collection"}
+	],"next_cursor":null}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable},
+		getErrs:   map[string]error{"skills/skill-collection": errors.New("500 server error")},
+	}
+
+	space := &models.Space{UUID: "u1", Name: "Recipes"}
+	if err := enrichSpaceSkills(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceSkills should be fail-soft on detail error, got: %v", err)
+	}
+	if len(space.Skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (metadata retained)", len(space.Skills))
+	}
+	sk := space.Skills[0]
+	if sk.ID != "skill-collection" || sk.Name != "git-commit" || sk.Description != "Commit helper" {
+		t.Errorf("skill = %+v, want summary metadata retained", sk)
+	}
+	if sk.Body != "" {
+		t.Errorf("body = %q, want empty (detail never fetched)", sk.Body)
+	}
+	// No body download should have been attempted.
+	if len(m.rawURLs) != 0 {
+		t.Errorf("attempted %d raw fetches, want 0", len(m.rawURLs))
+	}
+}
+
+// pagingGetter serves /rest/skills/selectable across multiple pages driven by a
+// cursor query param, and returns any other path from a static map.
+type pagingGetter struct {
+	// pages is indexed by the cursor value ("" for the first page).
+	pages  map[string]string
+	static map[string]string
+	paths  []string
+}
+
+func (p *pagingGetter) Get(_ context.Context, path string, dest any) error {
+	p.paths = append(p.paths, path)
+	if strings.Contains(path, "selectable") {
+		cursor := ""
+		if i := strings.Index(path, "cursor="); i >= 0 {
+			cursor = path[i+len("cursor="):]
+			if amp := strings.IndexByte(cursor, '&'); amp >= 0 {
+				cursor = cursor[:amp]
+			}
+		}
+		body, ok := p.pages[cursor]
+		if !ok {
+			return errors.New("no page for cursor: " + cursor)
+		}
+		return json.Unmarshal([]byte(body), dest)
+	}
+	for sub, body := range p.static {
+		if strings.Contains(path, sub) {
+			return json.Unmarshal([]byte(body), dest)
+		}
+	}
+	return errors.New("no canned response for path: " + path)
+}
+
+func TestListSpaceSkillsFollowsPagination(t *testing.T) {
+	p := &pagingGetter{pages: map[string]string{
+		"": `{"skills":[{"id":"s1","name":"one","scope":"collection"}],"next_cursor":"CUR2"}`,
+		"CUR2": `{"skills":[{"id":"s2","name":"two","scope":"global"}],"next_cursor":""}`,
+	}}
+
+	skills, err := ListSpaceSkills(context.Background(), p, "collection-uuid")
+	if err != nil {
+		t.Fatalf("ListSpaceSkills: %v", err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2 across both pages", len(skills))
+	}
+	if skills[0].ID != "s1" || skills[1].ID != "s2" {
+		t.Errorf("skills = %+v, want s1 then s2", skills)
+	}
+	// Second request must carry the cursor from the first page.
+	if len(p.paths) != 2 {
+		t.Fatalf("made %d requests, want 2", len(p.paths))
+	}
+	if !strings.Contains(p.paths[1], "cursor=CUR2") {
+		t.Errorf("second path = %q, want cursor=CUR2", p.paths[1])
+	}
+}
+
+func TestListSpaceSkillsStopsOnRepeatedCursor(t *testing.T) {
+	// A misbehaving API that keeps returning the same cursor must not loop
+	// forever.
+	p := &pagingGetter{pages: map[string]string{
+		"":     `{"skills":[{"id":"s1","name":"one","scope":"collection"}],"next_cursor":"LOOP"}`,
+		"LOOP": `{"skills":[{"id":"s2","name":"two","scope":"collection"}],"next_cursor":"LOOP"}`,
+	}}
+
+	skills, err := ListSpaceSkills(context.Background(), p, "collection-uuid")
+	if err != nil {
+		t.Fatalf("ListSpaceSkills: %v", err)
+	}
+	// First page + one LOOP page, then the repeated cursor stops iteration.
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2 before loop guard trips", len(skills))
+	}
+}
+
+func TestEnrichSpaceSkillsPropagatesCancellation(t *testing.T) {
+	selectable := `{"skills":[
+		{"id":"skill-collection","name":"git-commit","scope":"collection"}
+	],"next_cursor":null}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable},
+		getErrs:   map[string]error{"skills/skill-collection": context.Canceled},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	space := &models.Space{UUID: "u1", Name: "Recipes"}
+	err := enrichSpaceSkills(ctx, m, space)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled to propagate", err)
+	}
+}

--- a/internal/api/collections_test.go
+++ b/internal/api/collections_test.go
@@ -326,3 +326,111 @@ func TestEnrichSpaceSkillsPropagatesCancellation(t *testing.T) {
 		t.Errorf("err = %v, want context.Canceled to propagate", err)
 	}
 }
+
+func TestEnrichSpaceDetailSkipsEmptySlug(t *testing.T) {
+	m := &mockEnricher{} // no canned responses: any Get would error
+	space := &models.Space{UUID: "u1", Name: "Recipes"} // Slug == ""
+
+	if err := enrichSpaceDetail(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceDetail with empty slug = %v, want nil (skip)", err)
+	}
+	if len(m.paths) != 0 {
+		t.Errorf("issued %d requests for a slugless space, want 0", len(m.paths))
+	}
+}
+
+func TestEnrichSpaceSkillsSkipsEmptyUUID(t *testing.T) {
+	m := &mockEnricher{} // no canned responses: any Get would error
+	space := &models.Space{Slug: "recipes", Name: "Recipes"} // UUID == ""
+
+	if err := enrichSpaceSkills(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceSkills with empty uuid = %v, want nil (skip)", err)
+	}
+	if len(m.paths) != 0 {
+		t.Errorf("issued %d requests for a uuidless space, want 0", len(m.paths))
+	}
+	if len(space.Skills) != 0 {
+		t.Errorf("got %d skills for a uuidless space, want 0", len(space.Skills))
+	}
+}
+
+func TestEnrichSpaceSkillsEmptyFileURLSkipsBodyFetch(t *testing.T) {
+	// A skill whose detail carries no file_url is exported as metadata only,
+	// and no body download is attempted.
+	selectable := `{"skills":[
+		{"id":"skill-collection","name":"git-commit","scope":"collection"}
+	],"next_cursor":null}`
+	detail := `{"skill":{"id":"skill-collection","name":"git-commit","scope":"collection","file_url":""}}`
+	m := &mockEnricher{
+		responses: map[string]string{
+			"selectable":              selectable,
+			"skills/skill-collection": detail,
+		},
+	}
+
+	space := &models.Space{UUID: "u1", Name: "Recipes"}
+	if err := enrichSpaceSkills(context.Background(), m, space); err != nil {
+		t.Fatalf("enrichSpaceSkills: %v", err)
+	}
+	if len(space.Skills) != 1 {
+		t.Fatalf("got %d skills, want 1", len(space.Skills))
+	}
+	if space.Skills[0].Body != "" {
+		t.Errorf("body = %q, want empty (no file_url)", space.Skills[0].Body)
+	}
+	if len(m.rawURLs) != 0 {
+		t.Errorf("attempted %d raw fetches, want 0 (empty file_url)", len(m.rawURLs))
+	}
+}
+
+func TestEnrichSpacesFailSoftAcrossSpaces(t *testing.T) {
+	// Three spaces: the first has a failing detail fetch, the second a failing
+	// skills fetch, the third succeeds. All three must still be returned and
+	// the call must not error (fail-soft).
+	m := &mockEnricher{
+		responses: map[string]string{
+			"get_collection": `{"instructions":"ok"}`,
+			"selectable":     `{"skills":[],"next_cursor":null}`,
+		},
+		getErrs: map[string]error{
+			// Path substrings are matched before responses; scope the failures
+			// narrowly so only the intended space/endpoint is affected.
+			"collection_slug=bad-detail": errors.New("500 detail"),
+		},
+	}
+
+	items := []SpaceItem{
+		{UUID: "u1", Title: "BadDetail", Slug: "bad-detail"},
+		{UUID: "u2", Title: "Good", Slug: "good-slug"},
+	}
+
+	spaces, err := enrichSpaces(context.Background(), m, items)
+	if err != nil {
+		t.Fatalf("enrichSpaces should be fail-soft, got: %v", err)
+	}
+	if len(spaces) != 2 {
+		t.Fatalf("got %d spaces, want 2 (all retained despite one failure)", len(spaces))
+	}
+	// The failing-detail space still carries its list metadata.
+	if spaces[0].Name != "BadDetail" || spaces[0].Instructions != "" {
+		t.Errorf("space[0] = %+v, want metadata retained without instructions", spaces[0])
+	}
+	// The healthy space was enriched.
+	if spaces[1].Instructions != "ok" {
+		t.Errorf("space[1].Instructions = %q, want enriched", spaces[1].Instructions)
+	}
+}
+
+func TestEnrichSpacesPropagatesCancellation(t *testing.T) {
+	// A cancellation surfacing from any space must abort the whole loop.
+	m := &mockEnricher{
+		getErrs: map[string]error{"get_collection": context.Canceled},
+	}
+	items := []SpaceItem{{UUID: "u1", Title: "Recipes", Slug: "recipes"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := enrichSpaces(ctx, m, items); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled to propagate", err)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,5 +1,7 @@
 package api
 
+import "encoding/json"
+
 // These types represent the raw API response shapes from Perplexity's internal API.
 // Reverse-engineered from live API responses (May 2026, API version 2.18).
 
@@ -66,6 +68,91 @@ type SpaceItem struct {
 	Emoji       string `json:"emoji"`
 	Updated     string `json:"updated"`
 	HasNextPage bool   `json:"has_next_page"`
+}
+
+// --- Space Detail: GET /rest/collections/get_collection?collection_slug={slug} ---
+//
+// The spaces list endpoint omits per-space configuration (instructions,
+// description, suggested queries, primers). This detail endpoint carries them.
+// Note: the query param must be collection_slug — collection_uuid returns 422.
+
+// CollectionDetailResponse is the shape of GET /rest/collections/get_collection.
+type CollectionDetailResponse struct {
+	UUID                            string           `json:"uuid"`
+	Title                           string           `json:"title"`
+	Slug                            string           `json:"slug"`
+	Emoji                           string           `json:"emoji"`
+	URL                             string           `json:"url"`
+	Description                     string           `json:"description"`
+	Instructions                    string           `json:"instructions"`
+	KnowledgeDreamInstructions      string           `json:"knowledge_dream_instructions"`
+	ProjectStatusSummaryInstruction string           `json:"project_status_summary_instruction"`
+	SuggestedQueries                []SuggestedQuery `json:"suggested_queries"`
+	Primers                         []Primer         `json:"primers"`
+	FocusedWebConfig                json.RawMessage  `json:"focused_web_config"`
+	MemoryMode                      string           `json:"memory_mode"`
+	Access                          int              `json:"access"`
+	UserPermission                  int              `json:"user_permission"`
+	ThreadCount                     int              `json:"thread_count"`
+	PageCount                       int              `json:"page_count"`
+	FileCount                       int              `json:"file_count"`
+	UpdatedDatetime                 string           `json:"updated_datetime"`
+}
+
+// SuggestedQuery is a single suggested query on a space.
+type SuggestedQuery struct {
+	Query string `json:"query"`
+}
+
+// Primer is a primer entry on a space (grouped queries by type).
+type Primer struct {
+	PrimerType string   `json:"primer_type"`
+	Queries    []string `json:"queries"`
+}
+
+// --- Skills ---
+//
+// Space-attached skills are fetched via /rest/skills/selectable filtered by
+// collection_uuid. Space-specific skills carry scope=="collection"; global
+// skills carry scope=="global". Full skill detail (including a pre-signed S3
+// file_url for the SKILL.md body) comes from /rest/skills/{id}.
+
+// SkillsSelectableResponse is the shape of GET /rest/skills/selectable.
+type SkillsSelectableResponse struct {
+	Skills     []SkillSummary `json:"skills"`
+	NextCursor *string        `json:"next_cursor"`
+}
+
+// SkillSummary is a skill entry in the selectable list.
+type SkillSummary struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Description        string `json:"description"`
+	DisplayName        string `json:"display_name"`
+	DisplayDescription string `json:"display_description"`
+	Scope              string `json:"scope"`
+}
+
+// SkillDetailResponse is the shape of GET /rest/skills/{id}.
+type SkillDetailResponse struct {
+	IsOwner   bool             `json:"is_owner"`
+	IsCreator bool             `json:"is_creator"`
+	Enabled   bool             `json:"enabled"`
+	Installed bool             `json:"installed"`
+	Skill     SkillDetailInner `json:"skill"`
+}
+
+// SkillDetailInner is the nested skill object in the skill detail response.
+type SkillDetailInner struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Scope       string            `json:"scope"`
+	FileURL     string            `json:"file_url"`
+	Categories  []string          `json:"categories"`
+	Tags        map[string]string `json:"tags"`
+	CreatedAt   string            `json:"created_at"`
+	UpdatedAt   string            `json:"updated_at"`
 }
 
 // --- Thread Detail: GET /rest/thread/{uuid} ---

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -295,6 +296,22 @@ const maxRawURLBody = 10 << 20 // 10 MB
 // failure (ErrNotAuthenticated): the target is a third-party URL, so such a
 // status typically means the pre-signed URL has expired.
 func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
+	// Validate the target before issuing any request. The URL originates from
+	// the (authenticated) Perplexity API, but we still refuse anything that is
+	// not an absolute https URL with a host: skill bodies are always fetched
+	// from https pre-signed storage URLs, so a different scheme (http, file,
+	// etc.) or a missing host indicates a malformed or hostile value rather
+	// than a legitimate SKILL.md location. This is deliberately a lightweight
+	// check, not full SSRF hardening (no private-IP or redirect validation),
+	// which is out of scope for a personal export CLI fetching first-party URLs.
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return nil, fmt.Errorf("refusing to fetch non-https or hostless URL %q", rawURL)
+	}
+
 	httpAttempt := 0
 	netAttempt := 0
 
@@ -364,10 +381,15 @@ func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
 			}
 		}
 
-		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRawURLBody))
+		// Read one byte past the cap so an oversized body is detected as an
+		// explicit error rather than silently truncated into a corrupt skill.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRawURLBody+1))
 		resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("could not read response from %s: %w", rawURL, err)
+		}
+		if len(body) > maxRawURLBody {
+			return nil, fmt.Errorf("response from %s exceeds %d byte cap", rawURL, maxRawURLBody)
 		}
 
 		if resp.StatusCode != http.StatusOK {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -278,6 +278,106 @@ func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
 	}
 }
 
+// maxRawURLBody caps how much data GetRawURL will read into memory. Skill
+// SKILL.md bodies are small (KBs); this guards against a misdirected or
+// erroring pre-signed URL returning an unexpectedly large payload.
+const maxRawURLBody = 10 << 20 // 10 MB
+
+// GetRawURL fetches an absolute URL and returns the raw response body.
+//
+// Unlike Get/GetRaw, it does not prepend baseURL and does not attach the
+// Perplexity session cookie, Origin, or API headers. It is intended for
+// fetching pre-signed third-party URLs (e.g. S3-hosted skill bodies) that
+// require no authentication and must not receive our session cookie. It reuses
+// the same uTLS transport and the standard HTTP/network retry loops.
+//
+// Also unlike Get/GetRaw, a 401/403 is not treated as a Perplexity auth
+// failure (ErrNotAuthenticated): the target is a third-party URL, so such a
+// status typically means the pre-signed URL has expired.
+func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
+	httpAttempt := 0
+	netAttempt := 0
+
+	for {
+		if httpAttempt > maxRetries {
+			return nil, fmt.Errorf("request to %s failed after %d retries", rawURL, maxRetries)
+		}
+		if netAttempt > maxNetworkRetries {
+			return nil, fmt.Errorf("request to %s failed after %d network retries", rawURL, maxNetworkRetries)
+		}
+
+		// Reuse the shared inter-request pacing so a single client stays polite
+		// across mixed Perplexity/S3 traffic. The adaptive delay is capped
+		// (maxDelay) and skill bodies are fetched eagerly, so this stays well
+		// inside the pre-signed URL's ~15 min validity window. onSuccess/
+		// onRateLimited are intentionally NOT called: S3 rate limits are
+		// independent of Perplexity's and must not perturb its adaptive delay.
+		c.rateLimit()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not create request for %s: %w", rawURL, err)
+		}
+		// Minimal headers only; no auth cookie or Perplexity-specific headers.
+		req.Header.Set("User-Agent", UserAgent)
+		req.Header.Set("Accept", "*/*")
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			netAttempt++
+			backoff := computeBackoff(netAttempt-1, networkRetryBase, networkRetryMax)
+			if c.verbose {
+				log.Printf("[DEBUG] network error, backing off %s (attempt %d/%d): %v", backoff, netAttempt, maxNetworkRetries, err)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+				continue
+			}
+		}
+
+		netAttempt = 0
+
+		if c.verbose {
+			log.Printf("[DEBUG] %s %s → %d", req.Method, req.URL.String(), resp.StatusCode)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
+			resp.StatusCode == http.StatusGatewayTimeout {
+			resp.Body.Close()
+			httpAttempt++
+			backoff := computeBackoff(httpAttempt-1, baseBackoff, maxBackoff)
+			if c.verbose {
+				log.Printf("[DEBUG] retryable error %d, backing off %s (attempt %d/%d)", resp.StatusCode, backoff, httpAttempt, maxRetries)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+				continue
+			}
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRawURLBody))
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("could not read response from %s: %w", rawURL, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected response from %s: HTTP %d — %s", rawURL, resp.StatusCode, string(body))
+		}
+
+		return body, nil
+	}
+}
+
 // Post performs an authenticated POST request with a JSON body and decodes the response into dest.
 func (c *Client) Post(ctx context.Context, path string, body interface{}, dest interface{}) error {
 	fullURL := c.baseURL + path

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -84,6 +84,44 @@ func TestClientGetContextCancellation(t *testing.T) {
 	}
 }
 
+func TestGetRawURLIsolatesHeaders(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("skill body"))
+	}))
+	defer srv.Close()
+
+	// Client carries a session cookie that must NOT leak to the raw URL.
+	c := &Client{
+		http:    srv.Client(),
+		baseURL: "https://www.perplexity.ai",
+		delay:   0,
+		cookies: []*http.Cookie{{Name: "__Secure-next-auth.session-token", Value: "secret"}},
+	}
+
+	body, err := c.GetRawURL(context.Background(), srv.URL+"/skill/SKILL.md")
+	if err != nil {
+		t.Fatalf("GetRawURL: %v", err)
+	}
+	if string(body) != "skill body" {
+		t.Errorf("body = %q, want %q", string(body), "skill body")
+	}
+
+	// The Perplexity session cookie and API/Origin headers must be absent.
+	forbidden := []string{"Cookie", "Origin", "Referer", "X-App-Apiclient", "X-App-Apiversion"}
+	for _, h := range forbidden {
+		if v := got.Get(h); v != "" {
+			t.Errorf("GetRawURL leaked header %s = %q to third-party URL", h, v)
+		}
+	}
+	// User-Agent is still sent (benign, needed by some CDNs).
+	if got.Get("User-Agent") == "" {
+		t.Error("GetRawURL should still send a User-Agent")
+	}
+}
+
 func TestNewClient(t *testing.T) {
 	session := &models.SavedSession{
 		SessionToken: "tok",

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -86,7 +86,8 @@ func TestClientGetContextCancellation(t *testing.T) {
 
 func TestGetRawURLIsolatesHeaders(t *testing.T) {
 	var got http.Header
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// A TLS server so the URL is https, which GetRawURL requires.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("skill body"))
@@ -119,6 +120,44 @@ func TestGetRawURLIsolatesHeaders(t *testing.T) {
 	// User-Agent is still sent (benign, needed by some CDNs).
 	if got.Get("User-Agent") == "" {
 		t.Error("GetRawURL should still send a User-Agent")
+	}
+}
+
+func TestGetRawURLRejectsNonHTTPS(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := &Client{http: srv.Client(), baseURL: "https://www.perplexity.ai", delay: 0}
+
+	// srv.URL is an http:// URL; other schemes and hostless URLs are also
+	// refused. None of these should ever hit the network.
+	cases := []string{srv.URL + "/skill.md", "file:///etc/passwd", "https:///no-host"}
+	for _, raw := range cases {
+		if _, err := c.GetRawURL(context.Background(), raw); err == nil {
+			t.Errorf("GetRawURL(%q) = nil error, want rejection", raw)
+		}
+	}
+	if reached {
+		t.Error("GetRawURL issued a request for a rejected URL")
+	}
+}
+
+func TestGetRawURLRejectsOversizedBody(t *testing.T) {
+	// Serve one byte more than the cap; GetRawURL must error, not truncate.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(make([]byte, maxRawURLBody+1))
+	}))
+	defer srv.Close()
+
+	c := &Client{http: srv.Client(), baseURL: "https://www.perplexity.ai", delay: 0}
+
+	if _, err := c.GetRawURL(context.Background(), srv.URL+"/big.md"); err == nil {
+		t.Fatal("GetRawURL accepted an oversized body, want error")
 	}
 }
 

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/clappingmonkey/deplexity/internal/models"
@@ -148,11 +149,23 @@ func (e *JSONExporter) ExportSpaces(ctx context.Context, spaces []models.Space, 
 		threadByUUID[threads[i].UUID] = &threads[i]
 	}
 
-	for _, space := range spaces {
+	// Iterate by index (&spaces[i]) rather than a range copy: writeSpaceSkills
+	// records each skill's BodyFile in place, and that mutation must be visible
+	// to the space.json serialization below.
+	for i := range spaces {
+		space := &spaces[i]
 		spaceDir := filepath.Join(dir, sanitizeFilename(space.Name))
 		if err := os.MkdirAll(spaceDir, 0755); err != nil {
 			return fmt.Errorf("could not create space directory: %w", err)
 		}
+
+		// Write skill bodies as sidecar SKILL.md files and record their
+		// relative paths so space.json references them. Done before writing
+		// space.json so the body_file field is populated.
+		if err := e.writeSpaceSkills(spaceDir, space.Skills); err != nil {
+			return err
+		}
+
 		if err := writeJSON(filepath.Join(spaceDir, "space.json"), space); err != nil {
 			return err
 		}
@@ -208,6 +221,34 @@ func (e *JSONExporter) ExportManifest(manifest *models.ExportManifest) error {
 // threadDir returns the output directory for a thread.
 func (e *JSONExporter) threadDir(thread *models.Thread) string {
 	return filepath.Join(e.OutputDir, "threads", sanitizeFilename(threadSlug(thread)))
+}
+
+// writeSpaceSkills writes each skill's SKILL.md body into a skills/ subfolder
+// of the space directory and records the relative path on the skill so that
+// space.json references it. Skills without a fetched body are left as
+// metadata-only. It mutates the BodyFile field of each skill in place.
+func (e *JSONExporter) writeSpaceSkills(spaceDir string, skills []models.Skill) error {
+	filenames := skillFilenames(skills)
+	var skillsDir string
+	for i := range skills {
+		if skills[i].Body == "" {
+			continue
+		}
+		if skillsDir == "" {
+			skillsDir = filepath.Join(spaceDir, "skills")
+			if err := os.MkdirAll(skillsDir, 0755); err != nil {
+				return fmt.Errorf("could not create skills directory: %w", err)
+			}
+		}
+		filename := filenames[i]
+		if err := os.WriteFile(filepath.Join(skillsDir, filename), []byte(skills[i].Body), 0644); err != nil {
+			return fmt.Errorf("could not write skill body %s: %w", filename, err)
+		}
+		// Use path.Join (forward slashes) so body_file is portable in JSON
+		// consumed on any OS.
+		skills[i].BodyFile = path.Join("skills", filename)
+	}
+	return nil
 }
 
 // writeJSON writes data as indented JSON to a file atomically.

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -84,7 +84,10 @@ func TestExportSpacesWritesInstructionsAndSkills(t *testing.T) {
 		t.Fatalf("ExportSpaces: %v", err)
 	}
 
-	spaceDir := filepath.Join(dir, "spaces", "Recipes")
+	// The exporter sanitizes (and lowercases) the space name for the folder,
+	// so derive the expected path the same way rather than hardcoding "Recipes"
+	// (which passes on case-insensitive macOS but fails on case-sensitive Linux).
+	spaceDir := filepath.Join(dir, "spaces", sanitizeFilename(space.Name))
 
 	// The skill body file must exist with the fetched content.
 	bodyPath := filepath.Join(spaceDir, "skills", "git-commit.md")
@@ -116,7 +119,8 @@ func TestExportSpacesWritesInstructionsAndSkills(t *testing.T) {
 	if len(written.Skills) != 2 {
 		t.Fatalf("got %d skills in space.json, want 2", len(written.Skills))
 	}
-	if written.Skills[0].BodyFile != filepath.Join("skills", "git-commit.md") {
+	// BodyFile always uses forward slashes so it is portable inside JSON.
+	if written.Skills[0].BodyFile != "skills/git-commit.md" {
 		t.Errorf("BodyFile = %q, want skills/git-commit.md", written.Skills[0].BodyFile)
 	}
 	if written.Skills[1].BodyFile != "" {

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -1,8 +1,11 @@
 package export
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,6 +51,80 @@ func TestLoadCompleteThreadPreservesMetadata(t *testing.T) {
 	}
 	if !loaded.UpdatedAt.Equal(updatedAt) {
 		t.Errorf("UpdatedAt = %v, want %v", loaded.UpdatedAt, updatedAt)
+	}
+}
+
+func TestExportSpacesWritesInstructionsAndSkills(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+
+	space := models.Space{
+		UUID:         "e79179d1",
+		Name:         "Recipes",
+		Slug:         "recipes-55F50RUIQUK_fqfJUieN1w",
+		Instructions: "Test for the deplexity tool",
+		SuggestedQueries: []string{"How do I sear steak?"},
+		Skills: []models.Skill{
+			{
+				ID:    "skill-collection",
+				Name:  "git-commit",
+				Scope: "collection",
+				Body:  "---\nname: git-commit\n---\nCommit helper body",
+			},
+			{
+				ID:    "skill-nobody",
+				Name:  "no-body-skill",
+				Scope: "collection",
+				// No Body — metadata only, must not produce a file.
+			},
+		},
+	}
+
+	if err := exporter.ExportSpaces(context.Background(), []models.Space{space}, nil); err != nil {
+		t.Fatalf("ExportSpaces: %v", err)
+	}
+
+	spaceDir := filepath.Join(dir, "spaces", "Recipes")
+
+	// The skill body file must exist with the fetched content.
+	bodyPath := filepath.Join(spaceDir, "skills", "git-commit.md")
+	body, err := os.ReadFile(bodyPath)
+	if err != nil {
+		t.Fatalf("read skill body: %v", err)
+	}
+	if !strings.Contains(string(body), "Commit helper body") {
+		t.Errorf("skill body = %q, want the fetched SKILL.md", string(body))
+	}
+
+	// The body-less skill must not create a file.
+	if _, err := os.Stat(filepath.Join(spaceDir, "skills", "no-body-skill.md")); !os.IsNotExist(err) {
+		t.Errorf("body-less skill produced a file, want none (err=%v)", err)
+	}
+
+	// space.json must carry instructions and skills metadata with body_file set.
+	var written models.Space
+	raw, err := os.ReadFile(filepath.Join(spaceDir, "space.json"))
+	if err != nil {
+		t.Fatalf("read space.json: %v", err)
+	}
+	if err := json.Unmarshal(raw, &written); err != nil {
+		t.Fatalf("unmarshal space.json: %v", err)
+	}
+	if written.Instructions != "Test for the deplexity tool" {
+		t.Errorf("Instructions = %q, want sentinel", written.Instructions)
+	}
+	if len(written.Skills) != 2 {
+		t.Fatalf("got %d skills in space.json, want 2", len(written.Skills))
+	}
+	if written.Skills[0].BodyFile != filepath.Join("skills", "git-commit.md") {
+		t.Errorf("BodyFile = %q, want skills/git-commit.md", written.Skills[0].BodyFile)
+	}
+	if written.Skills[1].BodyFile != "" {
+		t.Errorf("body-less skill BodyFile = %q, want empty", written.Skills[1].BodyFile)
+	}
+	// Body must never be serialized into JSON.
+	if strings.Contains(string(raw), "Commit helper body") {
+		t.Error("space.json leaked the skill body; Body should be json:\"-\"")
 	}
 }
 

--- a/internal/export/markdown.go
+++ b/internal/export/markdown.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -117,11 +118,50 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 		if len(space.ThreadUUIDs) > 0 {
 			sb.WriteString(fmt.Sprintf("- **Threads:** %d\n", len(space.ThreadUUIDs)))
 		}
+
+		if len(space.SuggestedQueries) > 0 {
+			sb.WriteString("\n**Suggested Queries:**\n\n")
+			for _, q := range space.SuggestedQueries {
+				sb.WriteString(fmt.Sprintf("- %s\n", q))
+			}
+		}
+
+		if len(space.Primers) > 0 {
+			sb.WriteString("\n**Primers:**\n\n")
+			for _, p := range space.Primers {
+				sb.WriteString(fmt.Sprintf("- *%s*\n", p.PrimerType))
+				for _, q := range p.Queries {
+					sb.WriteString(fmt.Sprintf("  - %s\n", q))
+				}
+			}
+		}
+
+		if len(space.Skills) > 0 {
+			sb.WriteString("\n**Skills:**\n\n")
+			spaceSlug := sanitizeFilename(space.Name)
+			filenames := skillFilenames(space.Skills)
+			for i, sk := range space.Skills {
+				if sk.Body != "" {
+					// Link relative to spaces.md, which lives in the spaces dir.
+					// path.Join (forward slashes) keeps the Markdown link valid
+					// on every OS, unlike filepath.Join on Windows.
+					link := path.Join(spaceSlug, "skills", filenames[i])
+					sb.WriteString(fmt.Sprintf("- [%s](%s)", sk.Name, link))
+				} else {
+					sb.WriteString(fmt.Sprintf("- %s", sk.Name))
+				}
+				if sk.Description != "" {
+					sb.WriteString(fmt.Sprintf(" — %s", sk.Description))
+				}
+				sb.WriteString("\n")
+			}
+		}
+
 		sb.WriteString("\n---\n\n")
 	}
 
-	path := filepath.Join(dir, "spaces.md")
-	if err := os.WriteFile(path, []byte(sb.String()), 0644); err != nil {
+	spacesMD := filepath.Join(dir, "spaces.md")
+	if err := os.WriteFile(spacesMD, []byte(sb.String()), 0644); err != nil {
 		return fmt.Errorf("could not write spaces markdown: %w", err)
 	}
 
@@ -131,6 +171,13 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 		threadByUUID[threads[i].UUID] = &threads[i]
 	}
 	for _, space := range spaces {
+		spaceDir := filepath.Join(dir, sanitizeFilename(space.Name))
+
+		// Write skill bodies as SKILL.md sidecar files.
+		if err := writeSpaceSkillBodies(spaceDir, space.Skills); err != nil {
+			return err
+		}
+
 		for _, uuid := range space.ThreadUUIDs {
 			select {
 			case <-ctx.Done():
@@ -141,7 +188,6 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 			if thread == nil {
 				continue
 			}
-			spaceDir := filepath.Join(dir, sanitizeFilename(space.Name))
 			threadDir := filepath.Join(spaceDir, "threads", sanitizeFilename(threadSlug(thread)))
 			if err := writeThreadMarkdown(threadDir, thread); err != nil {
 				return err
@@ -149,6 +195,29 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 		}
 	}
 
+	return nil
+}
+
+// writeSpaceSkillBodies writes each skill's SKILL.md body into a skills/
+// subfolder of the space directory. Skills without a fetched body are skipped.
+func writeSpaceSkillBodies(spaceDir string, skills []models.Skill) error {
+	filenames := skillFilenames(skills)
+	var skillsDir string
+	for i := range skills {
+		if skills[i].Body == "" {
+			continue
+		}
+		if skillsDir == "" {
+			skillsDir = filepath.Join(spaceDir, "skills")
+			if err := os.MkdirAll(skillsDir, 0755); err != nil {
+				return fmt.Errorf("could not create skills directory: %w", err)
+			}
+		}
+		filename := filenames[i]
+		if err := os.WriteFile(filepath.Join(skillsDir, filename), []byte(skills[i].Body), 0644); err != nil {
+			return fmt.Errorf("could not write skill body %s: %w", filename, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/export/markdown.go
+++ b/internal/export/markdown.go
@@ -109,7 +109,9 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 			sb.WriteString(fmt.Sprintf("%s\n\n", space.Description))
 		}
 		if space.Instructions != "" {
-			sb.WriteString(fmt.Sprintf("**AI Instructions:**\n\n> %s\n\n", space.Instructions))
+			sb.WriteString("**AI Instructions:**\n\n")
+			sb.WriteString(blockquote(space.Instructions))
+			sb.WriteString("\n")
 		}
 		sb.WriteString(fmt.Sprintf("- **UUID:** %s\n", space.UUID))
 		if space.CreatedAt != nil {
@@ -248,4 +250,21 @@ func (e *MarkdownExporter) ExportUser(user *models.User) error {
 // threadDir returns the output directory for a thread.
 func (e *MarkdownExporter) threadDir(thread *models.Thread) string {
 	return filepath.Join(e.OutputDir, "threads", sanitizeFilename(threadSlug(thread)))
+}
+
+// blockquote renders text as a Markdown blockquote, prefixing every line with
+// "> " so multi-line instructions render correctly instead of collapsing into
+// a single quoted line. The result ends with a trailing newline.
+func blockquote(text string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			sb.WriteString(">\n")
+			continue
+		}
+		sb.WriteString("> ")
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }

--- a/internal/export/markdown_test.go
+++ b/internal/export/markdown_test.go
@@ -122,3 +122,46 @@ func TestMarkdownExportSpacesWithSkills(t *testing.T) {
 		t.Errorf("unexpected sidecar for body-less skill (err=%v)", err)
 	}
 }
+
+func TestBlockquoteMultiline(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"single line", "hello", "> hello\n"},
+		{"two lines", "line one\nline two", "> line one\n> line two\n"},
+		{"blank line between", "a\n\nb", "> a\n>\n> b\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := blockquote(tc.in); got != tc.want {
+				t.Errorf("blockquote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMarkdownExportSpacesMultilineInstructions(t *testing.T) {
+	tmpDir := t.TempDir()
+	exp := &MarkdownExporter{OutputDir: tmpDir}
+
+	spaces := []models.Space{{
+		UUID:         "space-1",
+		Name:         "Recipes",
+		Instructions: "First line.\nSecond line.",
+	}}
+	if err := exp.ExportSpaces(context.Background(), spaces, nil); err != nil {
+		t.Fatalf("ExportSpaces: %v", err)
+	}
+
+	overview, err := os.ReadFile(filepath.Join(tmpDir, "spaces", "spaces.md"))
+	if err != nil {
+		t.Fatalf("read spaces.md: %v", err)
+	}
+	content := string(overview)
+	// Every instruction line must be individually blockquoted.
+	if !strings.Contains(content, "> First line.\n> Second line.\n") {
+		t.Errorf("multiline instructions not blockquoted per line\n%s", content)
+	}
+}

--- a/internal/export/markdown_test.go
+++ b/internal/export/markdown_test.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,5 +58,67 @@ func TestMarkdownExportThread(t *testing.T) {
 		if !strings.Contains(content, check) {
 			t.Errorf("markdown missing %q", check)
 		}
+	}
+}
+
+func TestMarkdownExportSpacesWithSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+	exp := &MarkdownExporter{OutputDir: tmpDir}
+
+	spaces := []models.Space{
+		{
+			UUID:         "space-1",
+			Name:         "Recipes",
+			Description:  "A cooking space",
+			Instructions: "Test for the deplexity tool",
+			Skills: []models.Skill{
+				// Body-backed skill: gets a sidecar file and a link.
+				{ID: "s1", Name: "git-commit", Description: "Commit helper", Body: "# git-commit\nbody"},
+				// Metadata-only skill: rendered inline, no link, no file.
+				{ID: "s2", Name: "no-body", Description: "No body here"},
+			},
+		},
+	}
+
+	if err := exp.ExportSpaces(context.Background(), spaces, nil); err != nil {
+		t.Fatalf("ExportSpaces: %v", err)
+	}
+
+	// spaces.md content.
+	overview, err := os.ReadFile(filepath.Join(tmpDir, "spaces", "spaces.md"))
+	if err != nil {
+		t.Fatalf("read spaces.md: %v", err)
+	}
+	content := string(overview)
+
+	// Link uses forward slashes and the collision-free filename.
+	wantLink := "[git-commit](recipes/skills/git-commit.md)"
+	if !strings.Contains(content, wantLink) {
+		t.Errorf("spaces.md missing skill link %q\n%s", wantLink, content)
+	}
+	// Metadata-only skill is present but not linked.
+	if !strings.Contains(content, "- no-body — No body here") {
+		t.Errorf("spaces.md missing metadata-only skill line\n%s", content)
+	}
+	if strings.Contains(content, "no-body.md") {
+		t.Errorf("spaces.md should not link a body-less skill\n%s", content)
+	}
+	if !strings.Contains(content, "Test for the deplexity tool") {
+		t.Errorf("spaces.md missing instructions sentinel\n%s", content)
+	}
+
+	// The body sidecar file exists with the skill body.
+	bodyPath := filepath.Join(tmpDir, "spaces", "recipes", "skills", "git-commit.md")
+	body, err := os.ReadFile(bodyPath)
+	if err != nil {
+		t.Fatalf("read skill body: %v", err)
+	}
+	if string(body) != "# git-commit\nbody" {
+		t.Errorf("skill body = %q, want fetched SKILL.md", string(body))
+	}
+
+	// The body-less skill must not produce a sidecar file.
+	if _, err := os.Stat(filepath.Join(tmpDir, "spaces", "recipes", "skills", "no-body.md")); !os.IsNotExist(err) {
+		t.Errorf("unexpected sidecar for body-less skill (err=%v)", err)
 	}
 }

--- a/internal/export/util.go
+++ b/internal/export/util.go
@@ -39,3 +39,50 @@ func threadSlug(t *models.Thread) string {
 	}
 	return t.UUID
 }
+
+// skillFilenames returns a collision-free ".md" filename for each skill, keyed
+// by slice index. sanitizeFilename can map distinct skill names to the same
+// base (e.g. "C++ Helper" and "C# Helper" both collapse to "c-helper"), which
+// would otherwise cause one skill's body to silently overwrite another. When a
+// base name repeats, a short suffix derived from the unique skill ID is
+// appended. Both the JSON and Markdown exporters call this so they agree on the
+// on-disk filename and the links pointing at it.
+func skillFilenames(skills []models.Skill) []string {
+	names := make([]string, len(skills))
+
+	// Count how many skills map to each sanitized base name.
+	counts := make(map[string]int, len(skills))
+	for i := range skills {
+		counts[sanitizeFilename(skills[i].Name)]++
+	}
+
+	used := make(map[string]bool, len(skills))
+	for i := range skills {
+		base := sanitizeFilename(skills[i].Name)
+		name := base
+		if counts[base] > 1 {
+			name = base + "-" + shortID(skills[i].ID)
+		}
+		// Final guard against any residual collision (e.g. empty IDs).
+		for used[name] {
+			name += "-x"
+		}
+		used[name] = true
+		names[i] = name + ".md"
+	}
+	return names
+}
+
+// shortID returns a short, filesystem-safe fragment of a skill ID for
+// disambiguating filenames. Falls back to a sanitized form when the ID is
+// short or non-hex.
+func shortID(id string) string {
+	s := sanitizeFilename(id)
+	if s == "unnamed" {
+		return "id"
+	}
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
+}

--- a/internal/export/util_test.go
+++ b/internal/export/util_test.go
@@ -1,6 +1,10 @@
 package export
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
 
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {
@@ -35,5 +39,58 @@ func TestSanitizeFilenameLongInput(t *testing.T) {
 	got := sanitizeFilename(long)
 	if len(got) > 128 {
 		t.Errorf("expected length <= 128, got %d", len(got))
+	}
+}
+
+func TestSkillFilenamesDisambiguatesCollisions(t *testing.T) {
+	// "C++ Helper" and "C# Helper" both sanitize to "c-helper"; the third is
+	// unique. The two colliding entries must get distinct, ID-suffixed names.
+	skills := []models.Skill{
+		{ID: "aaaaaaaa1111", Name: "C++ Helper"},
+		{ID: "bbbbbbbb2222", Name: "C# Helper"},
+		{ID: "cccccccc3333", Name: "Recipes"},
+	}
+
+	got := skillFilenames(skills)
+	if len(got) != 3 {
+		t.Fatalf("got %d filenames, want 3", len(got))
+	}
+
+	// All filenames must be unique so no body overwrites another.
+	seen := map[string]bool{}
+	for i, name := range got {
+		if seen[name] {
+			t.Errorf("filename %q at index %d collides with an earlier skill", name, i)
+		}
+		seen[name] = true
+	}
+
+	// The colliding pair must be suffixed with a fragment of their unique IDs.
+	if got[0] == got[1] {
+		t.Errorf("colliding skills share filename %q", got[0])
+	}
+	if got[0] != "c-helper-aaaaaaaa.md" {
+		t.Errorf("got[0] = %q, want c-helper-aaaaaaaa.md", got[0])
+	}
+	if got[1] != "c-helper-bbbbbbbb.md" {
+		t.Errorf("got[1] = %q, want c-helper-bbbbbbbb.md", got[1])
+	}
+	// The unique skill keeps its plain base name (no suffix).
+	if got[2] != "recipes.md" {
+		t.Errorf("got[2] = %q, want recipes.md", got[2])
+	}
+}
+
+func TestSkillFilenamesUniqueNamesAreUnsuffixed(t *testing.T) {
+	skills := []models.Skill{
+		{ID: "x", Name: "git-commit"},
+		{ID: "y", Name: "pr-create"},
+	}
+	got := skillFilenames(skills)
+	want := []string{"git-commit.md", "pr-create.md"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // User represents a Perplexity user profile.
 type User struct {
@@ -47,6 +50,9 @@ type Source struct {
 }
 
 // Space represents a Perplexity Space (collection).
+//
+// Core identity fields (Name, UpdatedAt) keep their existing JSON keys for
+// backwards compatibility. Fields added for issue #61 use the raw API names.
 type Space struct {
 	UUID         string     `json:"uuid"`
 	Name         string     `json:"name"`
@@ -57,6 +63,48 @@ type Space struct {
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
 	UpdatedAt    time.Time  `json:"updated_at"`
 	ThreadUUIDs  []string   `json:"thread_uuids,omitempty"`
+
+	// Enrichment fields from GET /rest/collections/get_collection (issue #61).
+	URL                             string          `json:"url,omitempty"`
+	KnowledgeDreamInstructions      string          `json:"knowledge_dream_instructions,omitempty"`
+	ProjectStatusSummaryInstruction string          `json:"project_status_summary_instruction,omitempty"`
+	SuggestedQueries                []string        `json:"suggested_queries,omitempty"`
+	Primers                         []Primer        `json:"primers,omitempty"`
+	FocusedWebConfig                json.RawMessage `json:"focused_web_config,omitempty"`
+	MemoryMode                      string          `json:"memory_mode,omitempty"`
+	Access                          int             `json:"access,omitempty"`
+	UserPermission                  int             `json:"user_permission,omitempty"`
+	ThreadCount                     int             `json:"thread_count,omitempty"`
+	PageCount                       int             `json:"page_count,omitempty"`
+	FileCount                       int             `json:"file_count,omitempty"`
+
+	// Skills attached to this space (scope == "collection").
+	Skills []Skill `json:"skills,omitempty"`
+}
+
+// Primer is a primer entry on a space (grouped queries by type).
+type Primer struct {
+	PrimerType string   `json:"primer_type"`
+	Queries    []string `json:"queries"`
+}
+
+// Skill represents a skill attached to a space. The SKILL.md body is fetched
+// during enrichment (the source URL is a short-lived pre-signed link) and
+// written to a sidecar file by the exporters; it is not embedded in JSON.
+type Skill struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Scope       string            `json:"scope,omitempty"`
+	Categories  []string          `json:"categories,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	UpdatedAt   string            `json:"updated_at,omitempty"`
+	// BodyFile is the relative path to the written SKILL.md (e.g. "skills/git-commit.md").
+	BodyFile string `json:"body_file,omitempty"`
+	// Body holds the fetched SKILL.md content. Not serialized to JSON; written
+	// to a sidecar file by the exporters.
+	Body string `json:"-"`
 }
 
 // ExportManifest holds metadata about an export run.


### PR DESCRIPTION
#### Description

The `/rest/spaces` list endpoint returns only minimal metadata (uuid,
title, slug, emoji, updated) and drops each space's custom AI instructions
and configuration. This adds always-on, fail-soft enrichment that captures
the full per-space context in the export.

For every space, `ListCollections` now fetches:
- **Per-space detail** via `get_collection?collection_slug={slug}` (must use
  slug; `collection_uuid` returns 422): instructions, description,
  suggested_queries, primers, memory mode, and counts.
- **Collection-scoped skills** via `skills/selectable` + `skills/{id}`, then
  downloads each `SKILL.md` body from its short-lived pre-signed S3 URL.

Skill bodies are carried in-memory (`Skill.Body`, `json:"-"`) and written as
`spaces/<name>/skills/<name>.md` sidecars by the JSON and Markdown exporters;
metadata lands in `space.json` under `skills`. Global-scope skills are
excluded for now (follow-up tracked in TODO).

A new `client.GetRawURL` fetches absolute third-party URLs without the
Perplexity session cookie or API headers, with a 10 MB read cap.

Enrichment is fail-soft per space and per skill, but context cancellation
propagates and aborts the export. Skill listing follows `next_cursor`
pagination with a repeat-cursor guard, and skill filenames are disambiguated
by ID to avoid collisions from sanitized names.

**Motivation/Context:** Closes #61. Users relying on Deplexity to back up
their Perplexity data were losing all space-level customization (custom
instructions, attached skills) because the list endpoint omits it.

**Tests Executed:** `go test ./...` and `bazel test //...` (5/5 targets pass).
Live-verified with `deplexity export --spaces` against the Recipes sentinel
space: instructions, the `git-commit` collection-scoped skill (global
`create-skill` correctly excluded), the `body_file` sidecar with real SKILL.md
content, no raw body leaking into `space.json`, and the rendered Markdown link.

---

#### Checklist

 * [ ] Change was tested in staging environment successfully
 * [x] Change has been documented
 * [x] I have commented my code, particularly in hard-to-understand areas
 * [x] I have added tests that prove my fix is effective or that my feature works

---

#### General PR information (references)

Issue: #61
Depends-On: N/A