### PR TITLE
feat: export account-wide global skills once at top level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Binary entrypoint: `cmd/deplexity/main.go`. Version/buildTime stamped via `x_def
 
 - `internal/api/types.go` — **raw API response structs** (JSON tags match Perplexity's undocumented internal API, verified against live responses May 2026, API v2.18).
 - `internal/api/threads.go` — `ListThreads`, `ListThreadsFrom` (POST `list_ask_threads` with pagination, dual stop condition), `GetThread`.
-- `internal/api/collections.go` — `ListCollections` via `GET /rest/spaces`, then always-on fail-soft enrichment: `GetCollection` (per-space instructions/description/suggested_queries/primers) and `ListSpaceSkills`/`GetSkillDetail` (collection-scoped skills + SKILL.md body).
+- `internal/api/collections.go` — `ListCollections` via `GET /rest/spaces`, then always-on fail-soft enrichment: `GetCollection` (per-space instructions/description/suggested_queries/primers) and `ListSpaceSkills`/`GetSkillDetail` (collection-scoped skills + SKILL.md body). `ListSpaceSkills` omits `collection_uuid` when the UUID is empty (used to list account-wide global skills).
+- `internal/api/skills.go` — account-wide skills. `enrichSkill` (shared fail-soft helper: fetches detail + downloads SKILL.md body, used by both space and global paths), `ListGlobalSkills` (calls `ListSpaceSkills("")`, keeps only `scope=="global"`), and `GetAccount` (wraps global skills in `models.Account`). Global skills apply to every request account-wide, so they are exported **once** at the top level, not per space.
 - `internal/api/user.go` — `GetUser` via `GET /api/user`.
 - `internal/models/models.go` — clean domain models used throughout the app (decoupled from API shape).
 - `internal/auth/` — browser-based login via `go-rod/rod` (visible Chrome), cookie capture, session persistence. Also supports `--cookie` for manual token auth.
@@ -68,6 +69,7 @@ All endpoints are reverse-engineered from browser DevTools (May 2026, API versio
 | GET | `/rest/spaces` | All spaces (private/shared/invited/org/saved) — list only, omits instructions/skills |
 | GET | `/rest/collections/get_collection?collection_slug={slug}` | Per-space detail: instructions, description, suggested_queries, primers (param must be `collection_slug`; `collection_uuid` → 422) |
 | GET | `/rest/skills/selectable?collection_uuid={uuid}` | Skills selectable in a space; space-attached skills have `scope=="collection"` (vs `global`) |
+| GET | `/rest/skills/selectable` (no `collection_uuid`) | Account-wide skills; returns only `scope=="global"` entries (applied to every request) |
 | GET | `/rest/skills/{id}?view_scope=individual` | Skill detail incl. pre-signed S3 `file_url` for the SKILL.md body |
 | GET | `/api/user` | User profile |
 | GET | `/api/auth/session` | Session info + expiry |
@@ -83,7 +85,7 @@ Answer content is in `entries[].blocks[]` where `intended_usage == "ask_text_0_m
 
 1. **Phase 1 — Index**: `POST /rest/thread/list_ask_threads` with pagination (limit=20, ascending=false). Dual stop condition: `len(response) < limit` (primary) + all-duplicates (safety net). Result cached in `thread_index.json` with `Complete: true` flag.
 2. **Phase 2 — Details**: `GET /rest/thread/{uuid}` for each thread. Skips threads already fetched on disk. Adaptive rate limiting: delay doubles after 429, halves after 20 consecutive successes.
-3. **Phase 3 — Render**: Convert domain models to JSON/Markdown/PDF. Write threads to `threads/<slug>/` (canonical flat list). Copy thread files into `spaces/<name>/threads/<slug>/` so each space folder is self-contained.
+3. **Phase 3 — Render**: Convert domain models to JSON/Markdown/PDF. Write threads to `threads/<slug>/` (canonical flat list). Copy thread files into `spaces/<name>/threads/<slug>/` so each space folder is self-contained. Account-wide global skills are written **once** under `account/`: `account/account.json` (JSON) + `account/global-skills.md` (Markdown), with each skill body in `account/skills/<name>.md`. They are not duplicated per space.
 
 Use `--refresh` to force re-fetching the thread index.
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ deplexity-export/
 ├── thread_index.json          # Cached thread list (for resumable exports)
 ├── profile/
 │   └── user.json
+├── account/                   # Account-wide data (not tied to any space)
+│   ├── account.json           # Global skills metadata (referenced bodies below)
+│   ├── global-skills.md       # Global skills overview (Markdown)
+│   └── skills/                # Global skills' SKILL.md bodies
+│       └── <skill-name>.md
 ├── spaces/
 │   ├── index.json
 │   ├── spaces.md
@@ -151,6 +156,8 @@ deplexity-export/
 Each space folder is self-contained — you can ZIP and share a single space without needing the top-level `threads/` directory.
 
 Space exports capture each space's full context: its custom AI instructions, description, suggested queries, primers, and any attached skills. Skill definitions are written as `SKILL.md` files under `spaces/<space-name>/skills/` and referenced from `space.json`.
+
+Account-wide **global skills** apply to every request regardless of space, so they are exported once under `account/` rather than duplicated per space. They are captured when spaces are exported (skip them with `--no-spaces`) and are written to JSON and Markdown outputs (`account/account.json`, `account/global-skills.md`, and bodies under `account/skills/`); PDF-only exports do not include them.
 
 ---
 

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -167,9 +167,31 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 		fmt.Printf(" %s\n", user.Email)
 	}
 
+	// === Account (global skills) ===
+	// Global skills are account-wide and apply to every request regardless of
+	// space, so they are fetched once here rather than attached per space.
+	// They are skill configuration like space skills, so --no-spaces suppresses
+	// them too, keeping that flag's "skip skill fetching" intent intact.
+	var account *models.Account
+	if cmd.Spaces {
+		fmt.Print("Fetching global skills...")
+		account, err = api.GetAccount(ctx, c)
+		if err != nil {
+			// Cancellation must abort the whole export; other errors are a
+			// skipped section, matching how spaces are handled above.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, " skipped (%v)\n", err)
+			account = nil
+		} else {
+			fmt.Printf(" %d global skills found\n", len(account.GlobalSkills))
+		}
+	}
+
 	// === Phase 3: Format export ===
 	for _, format := range cmd.Format {
-		if err := cmd.exportFormat(ctx, format, threads, spaces, user); err != nil {
+		if err := cmd.exportFormat(ctx, format, threads, spaces, user, account); err != nil {
 			return fmt.Errorf("export %s failed: %w", format, err)
 		}
 	}
@@ -184,6 +206,9 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 			Spaces:  len(spaces),
 		},
 		ThreadIndex: make(map[string]string),
+	}
+	if account != nil {
+		manifest.Counts.GlobalSkills = len(account.GlobalSkills)
 	}
 	for _, t := range threads {
 		manifest.ThreadIndex[t.UUID] = t.Slug
@@ -419,7 +444,7 @@ func attachPreviousUpdatedAt(refs []models.ThreadRef, previous []models.ThreadRe
 	}
 }
 
-func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads []models.Thread, spaces []models.Space, user *models.User) error {
+func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads []models.Thread, spaces []models.Space, user *models.User, account *models.Account) error {
 	total := len(threads)
 
 	switch format {
@@ -439,6 +464,11 @@ func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads [
 		}
 		if user != nil {
 			if err := exp.ExportUser(user); err != nil {
+				return err
+			}
+		}
+		if account != nil {
+			if err := exp.ExportAccount(account); err != nil {
 				return err
 			}
 		}
@@ -471,6 +501,11 @@ func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads [
 		}
 		if user != nil {
 			if err := exp.ExportUser(user); err != nil {
+				return err
+			}
+		}
+		if account != nil {
+			if err := exp.ExportAccount(account); err != nil {
 				return err
 			}
 		}

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -140,6 +143,39 @@ func TestFinalizeIndex(t *testing.T) {
 			}
 			if reloaded.Complete != tt.wantComplete {
 				t.Errorf("persisted Complete = %t, want %t", reloaded.Complete, tt.wantComplete)
+			}
+		})
+	}
+}
+
+// TestExportFormatAccountGating locks in the render half of the --no-spaces
+// gate: when spaces (and thus global skills) are disabled, Run leaves account
+// nil, and exportFormat must then write no account/ output for any format. The
+// positive case confirms a non-nil account does produce account/ output.
+func TestExportFormatAccountGating(t *testing.T) {
+	for _, format := range []string{"json", "markdown"} {
+		t.Run(format+"/nil account writes nothing", func(t *testing.T) {
+			dir := t.TempDir()
+			cmd := &ExportCmd{Output: dir, Format: []string{format}}
+			if err := cmd.exportFormat(context.Background(), format, nil, nil, nil, nil); err != nil {
+				t.Fatalf("exportFormat: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "account")); !os.IsNotExist(err) {
+				t.Errorf("nil account produced account/ output (err=%v)", err)
+			}
+		})
+
+		t.Run(format+"/non-nil account writes output", func(t *testing.T) {
+			dir := t.TempDir()
+			cmd := &ExportCmd{Output: dir, Format: []string{format}}
+			account := &models.Account{GlobalSkills: []models.Skill{
+				{ID: "g1", Name: "create-skill", Scope: "global", Body: "body"},
+			}}
+			if err := cmd.exportFormat(context.Background(), format, nil, nil, nil, account); err != nil {
+				t.Fatalf("exportFormat: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "account")); err != nil {
+				t.Errorf("non-nil account produced no account/ output: %v", err)
 			}
 		})
 	}

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "api",
     srcs = [
         "collections.go",
+        "skills.go",
         "threads.go",
         "types.go",
         "user.go",
@@ -20,6 +21,7 @@ go_test(
     name = "api_test",
     srcs = [
         "collections_test.go",
+        "skills_test.go",
         "threads_test.go",
         "user_test.go",
     ],

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -123,6 +123,10 @@ func GetCollection(ctx context.Context, c getter, slug string) (*CollectionDetai
 // ListSpaceSkills fetches the skills selectable within a space via
 // GET /rest/skills/selectable?collection_uuid={uuid}, following next_cursor
 // pagination so that spaces with many skills are fully captured.
+//
+// When collectionUUID is empty the collection_uuid parameter is omitted, which
+// the API interprets as "list account-wide skills": the response then carries
+// only scope=="global" skills. ListGlobalSkills relies on this behaviour.
 func ListSpaceSkills(ctx context.Context, c getter, collectionUUID string) ([]SkillSummary, error) {
 	var all []SkillSummary
 	cursor := ""
@@ -132,9 +136,12 @@ func ListSpaceSkills(ctx context.Context, c getter, collectionUUID string) ([]Sk
 
 	for {
 		path := fmt.Sprintf(
-			"/rest/skills/selectable?collection_uuid=%s&version=%s&source=default",
-			url.QueryEscape(collectionUUID), apiVersion,
+			"/rest/skills/selectable?version=%s&source=default",
+			apiVersion,
 		)
+		if collectionUUID != "" {
+			path += "&collection_uuid=" + url.QueryEscape(collectionUUID)
+		}
 		if cursor != "" {
 			path += "&cursor=" + url.QueryEscape(cursor)
 		}
@@ -150,7 +157,11 @@ func ListSpaceSkills(ctx context.Context, c getter, collectionUUID string) ([]Sk
 		}
 		if seenCursors[*resp.NextCursor] {
 			// The cursor is repeating; stop rather than loop forever.
-			log.Printf("warning: skills pagination cursor repeated for space %s; stopping", collectionUUID)
+			owner := collectionUUID
+			if owner == "" {
+				owner = "global"
+			}
+			log.Printf("warning: skills pagination cursor repeated for %s; stopping", owner)
 			break
 		}
 		seenCursors[*resp.NextCursor] = true
@@ -216,9 +227,10 @@ func enrichSpaceDetail(ctx context.Context, c getter, space *models.Space) error
 // including each skill's SKILL.md body. Per-skill failures are logged and
 // skipped so one bad skill does not drop the others.
 //
-// Only skills with scope=="collection" (space-specific) are exported. Global
-// skills available to the space are intentionally excluded for now; see the
-// follow-up noted in TODO.md.
+// Only skills with scope=="collection" (space-specific) are attached to a
+// space. Account-wide skills (scope=="global") apply to every request
+// regardless of space and are exported once at the account level via
+// GetAccount/ListGlobalSkills, so they are deliberately skipped here.
 func enrichSpaceSkills(ctx context.Context, c enricher, space *models.Space) error {
 	// skills/selectable is keyed by collection UUID; without one there is
 	// nothing to fetch.
@@ -236,40 +248,11 @@ func enrichSpaceSkills(ctx context.Context, c enricher, space *models.Space) err
 			continue
 		}
 
-		skill := models.Skill{
-			ID:          s.ID,
-			Name:        s.Name,
-			Description: s.Description,
-			Scope:       s.Scope,
-		}
-
-		// Fetch full detail (metadata + pre-signed body URL).
-		detail, err := GetSkillDetail(ctx, c, s.ID)
+		skill, err := enrichSkill(ctx, c, s, fmt.Sprintf("space %q", space.Name))
 		if err != nil {
-			if isCancellation(err) {
-				return err
-			}
-			log.Printf("warning: could not fetch detail for skill %q in space %q: %v", s.Name, space.Name, err)
-			space.Skills = append(space.Skills, skill)
-			continue
-		}
-
-		skill.Categories = detail.Skill.Categories
-		skill.Tags = detail.Skill.Tags
-		skill.CreatedAt = detail.Skill.CreatedAt
-		skill.UpdatedAt = detail.Skill.UpdatedAt
-
-		// Download the SKILL.md body now — the URL is short-lived (~15 min).
-		if detail.Skill.FileURL != "" {
-			body, err := c.GetRawURL(ctx, detail.Skill.FileURL)
-			if err != nil {
-				if isCancellation(err) {
-					return err
-				}
-				log.Printf("warning: could not download body for skill %q in space %q: %v", s.Name, space.Name, err)
-			} else {
-				skill.Body = string(body)
-			}
+			// Only cancellation is returned; other failures degrade to
+			// metadata-only and are already logged.
+			return err
 		}
 
 		space.Skills = append(space.Skills, skill)

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
+
+// enrichSkill converts a skill summary into a full domain Skill by fetching its
+// detail (metadata + pre-signed body URL) and downloading the SKILL.md body.
+//
+// It is fail-soft: a non-cancellation failure to fetch detail or download the
+// body degrades to the metadata already known from the summary (logged, never
+// fatal), so one bad skill never drops the others. Context cancellation is the
+// sole error returned — it must abort the surrounding enumeration rather than
+// be mistaken for a skill that simply has no body.
+//
+// ownerLabel describes the context the skill was found in (e.g. `space "Foo"`
+// or "account") and is used only in warning messages.
+func enrichSkill(ctx context.Context, c enricher, s SkillSummary, ownerLabel string) (models.Skill, error) {
+	skill := models.Skill{
+		ID:          s.ID,
+		Name:        s.Name,
+		Description: s.Description,
+		Scope:       s.Scope,
+	}
+
+	// Fetch full detail (metadata + pre-signed body URL).
+	detail, err := GetSkillDetail(ctx, c, s.ID)
+	if err != nil {
+		if isCancellation(err) {
+			return models.Skill{}, err
+		}
+		log.Printf("warning: could not fetch detail for skill %q in %s: %v", s.Name, ownerLabel, err)
+		return skill, nil
+	}
+
+	skill.Categories = detail.Skill.Categories
+	skill.Tags = detail.Skill.Tags
+	skill.CreatedAt = detail.Skill.CreatedAt
+	skill.UpdatedAt = detail.Skill.UpdatedAt
+
+	// Download the SKILL.md body now — the URL is short-lived (~15 min).
+	if detail.Skill.FileURL != "" {
+		body, err := c.GetRawURL(ctx, detail.Skill.FileURL)
+		if err != nil {
+			if isCancellation(err) {
+				return models.Skill{}, err
+			}
+			log.Printf("warning: could not download body for skill %q in %s: %v", s.Name, ownerLabel, err)
+		} else {
+			skill.Body = string(body)
+		}
+	}
+
+	return skill, nil
+}
+
+// ListGlobalSkills fetches account-wide skills (scope == "global") and enriches
+// each with its detail and SKILL.md body.
+//
+// Global skills apply to every request regardless of space. They are listed via
+// GET /rest/skills/selectable with no collection_uuid, which returns only the
+// global-scoped skills. Enrichment is best-effort: a per-skill failure is
+// logged and the skill is retained as metadata-only, so one broken skill never
+// drops the rest. Context cancellation aborts and propagates.
+func ListGlobalSkills(ctx context.Context, c enricher) ([]models.Skill, error) {
+	summaries, err := ListSpaceSkills(ctx, c, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list global skills: %w", err)
+	}
+
+	var skills []models.Skill
+	seen := map[string]bool{}
+	for _, s := range summaries {
+		// The selectable endpoint without a collection_uuid should only return
+		// global skills, but filter defensively in case the API interleaves
+		// other scopes.
+		if s.Scope != "global" {
+			continue
+		}
+		// Guard against the paginated list returning the same skill twice,
+		// which would otherwise be enriched, written, and counted twice.
+		if s.ID != "" && seen[s.ID] {
+			continue
+		}
+		seen[s.ID] = true
+
+		skill, err := enrichSkill(ctx, c, s, "account")
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, skill)
+	}
+
+	return skills, nil
+}
+
+// GetAccount fetches account-wide data. It currently gathers global skills; the
+// Account wrapper leaves room for future account-scoped resources without
+// reshaping the export surface.
+func GetAccount(ctx context.Context, c enricher) (*models.Account, error) {
+	skills, err := ListGlobalSkills(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	return &models.Account{GlobalSkills: skills}, nil
+}

--- a/internal/api/skills_test.go
+++ b/internal/api/skills_test.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/clappingmonkey/deplexity/internal/models"
+)
+
+func TestListSpaceSkillsOmitsCollectionUUIDWhenEmpty(t *testing.T) {
+	// An empty collectionUUID must produce a selectable request with no
+	// collection_uuid param — the API returns only global skills in that case.
+	m := &mockEnricher{responses: map[string]string{
+		"selectable": `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":null}`,
+	}}
+
+	skills, err := ListSpaceSkills(context.Background(), m, "")
+	if err != nil {
+		t.Fatalf("ListSpaceSkills: %v", err)
+	}
+	if len(skills) != 1 || skills[0].ID != "g1" {
+		t.Fatalf("skills = %+v, want one global skill g1", skills)
+	}
+	if len(m.paths) != 1 {
+		t.Fatalf("made %d requests, want 1", len(m.paths))
+	}
+	if strings.Contains(m.paths[0], "collection_uuid") {
+		t.Errorf("path = %q, must omit collection_uuid for the global list", m.paths[0])
+	}
+}
+
+func TestListSpaceSkillsIncludesCollectionUUIDWhenSet(t *testing.T) {
+	// A non-empty UUID keeps the existing per-space behaviour.
+	m := &mockEnricher{responses: map[string]string{
+		"selectable": `{"skills":[],"next_cursor":null}`,
+	}}
+
+	if _, err := ListSpaceSkills(context.Background(), m, "u1"); err != nil {
+		t.Fatalf("ListSpaceSkills: %v", err)
+	}
+	if len(m.paths) != 1 || !strings.Contains(m.paths[0], "collection_uuid=u1") {
+		t.Errorf("path = %q, want collection_uuid=u1", m.paths[0])
+	}
+}
+
+func TestListGlobalSkillsFiltersGlobalScopeAndFetchesBody(t *testing.T) {
+	// selectable (no collection) returns a global skill; it must be enriched
+	// with detail + body. A non-global entry, if present, is ignored.
+	selectable := `{"skills":[
+		{"id":"g1","name":"create-skill","description":"Create skills","scope":"global"},
+		{"id":"c1","name":"stray","description":"should be ignored","scope":"collection"}
+	],"next_cursor":null}`
+	detail := `{"skill":{"id":"g1","name":"create-skill","description":"Create skills","scope":"global",
+		"file_url":"https://s3.example.com/create-skill/SKILL.md?sig=abc",
+		"categories":["meta"],"tags":{"selectable":"true"},
+		"created_at":"2026-02-26T21:59:08","updated_at":"2026-08-27T19:29:45"}}`
+	m := &mockEnricher{
+		responses: map[string]string{
+			"selectable": selectable,
+			"skills/g1":  detail,
+		},
+		rawBodies: map[string]string{
+			"https://s3.example.com/create-skill/SKILL.md?sig=abc": "---\nname: create-skill\n---\nbody",
+		},
+	}
+
+	skills, err := ListGlobalSkills(context.Background(), m)
+	if err != nil {
+		t.Fatalf("ListGlobalSkills: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (global only)", len(skills))
+	}
+	sk := skills[0]
+	if sk.ID != "g1" || sk.Name != "create-skill" || sk.Scope != "global" {
+		t.Errorf("skill = %+v, want global create-skill", sk)
+	}
+	if sk.Body != "---\nname: create-skill\n---\nbody" {
+		t.Errorf("body = %q, want fetched SKILL.md", sk.Body)
+	}
+	if len(sk.Categories) != 1 || sk.Categories[0] != "meta" {
+		t.Errorf("categories = %v, want [meta]", sk.Categories)
+	}
+	// Only the global skill's detail should be fetched (the collection stray
+	// is filtered before enrichment).
+	for _, p := range m.paths {
+		if strings.Contains(p, "skills/c1") {
+			t.Errorf("fetched detail for filtered collection skill: %q", p)
+		}
+	}
+}
+
+func TestListGlobalSkillsFailSoftOnBodyDownload(t *testing.T) {
+	selectable := `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":null}`
+	detail := `{"skill":{"id":"g1","name":"create-skill","scope":"global",
+		"file_url":"https://s3.example.com/broken/SKILL.md"}}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable, "skills/g1": detail},
+		rawErrs:   map[string]error{"https://s3.example.com/broken/SKILL.md": errors.New("403 expired")},
+	}
+
+	skills, err := ListGlobalSkills(context.Background(), m)
+	if err != nil {
+		t.Fatalf("ListGlobalSkills should be fail-soft on body error, got: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (metadata retained)", len(skills))
+	}
+	if skills[0].Body != "" {
+		t.Errorf("body = %q, want empty after failed download", skills[0].Body)
+	}
+}
+
+func TestListGlobalSkillsFailSoftOnDetailError(t *testing.T) {
+	selectable := `{"skills":[{"id":"g1","name":"create-skill","description":"Create skills","scope":"global"}],"next_cursor":null}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable},
+		getErrs:   map[string]error{"skills/g1": errors.New("500 server error")},
+	}
+
+	skills, err := ListGlobalSkills(context.Background(), m)
+	if err != nil {
+		t.Fatalf("ListGlobalSkills should be fail-soft on detail error, got: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (metadata retained)", len(skills))
+	}
+	if skills[0].ID != "g1" || skills[0].Description != "Create skills" {
+		t.Errorf("skill = %+v, want summary metadata retained", skills[0])
+	}
+	if skills[0].Body != "" {
+		t.Errorf("body = %q, want empty (detail never fetched)", skills[0].Body)
+	}
+}
+
+func TestListGlobalSkillsPropagatesCancellation(t *testing.T) {
+	selectable := `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":null}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable},
+		getErrs:   map[string]error{"skills/g1": context.Canceled},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ListGlobalSkills(ctx, m); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled to propagate", err)
+	}
+}
+
+func TestGetAccountWrapsGlobalSkills(t *testing.T) {
+	selectable := `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":null}`
+	detail := `{"skill":{"id":"g1","name":"create-skill","scope":"global","file_url":""}}`
+	m := &mockEnricher{
+		responses: map[string]string{"selectable": selectable, "skills/g1": detail},
+	}
+
+	account, err := GetAccount(context.Background(), m)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	var _ *models.Account = account // GetAccount must return *models.Account
+	if account == nil {
+		t.Fatal("account is nil")
+	}
+	if len(account.GlobalSkills) != 1 || account.GlobalSkills[0].ID != "g1" {
+		t.Errorf("GlobalSkills = %+v, want one skill g1", account.GlobalSkills)
+	}
+}
+
+// pagingEnricher adds a no-op GetRawURL to pagingGetter so it satisfies the
+// enricher interface required by ListGlobalSkills. Bodies are never exercised
+// here (the skills under test carry no file_url), so an empty body suffices.
+type pagingEnricher struct {
+	*pagingGetter
+}
+
+func (pagingEnricher) GetRawURL(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+func TestListGlobalSkillsDeduplicatesAcrossPages(t *testing.T) {
+	// The same global skill appears on both pages; it must be enriched,
+	// returned, and counted only once.
+	p := &pagingEnricher{&pagingGetter{
+		pages: map[string]string{
+			"":     `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":"CUR2"}`,
+			"CUR2": `{"skills":[{"id":"g1","name":"create-skill","scope":"global"}],"next_cursor":""}`,
+		},
+		static: map[string]string{
+			"skills/g1": `{"skill":{"id":"g1","name":"create-skill","scope":"global","file_url":""}}`,
+		},
+	}}
+
+	skills, err := ListGlobalSkills(context.Background(), p)
+	if err != nil {
+		t.Fatalf("ListGlobalSkills: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (deduplicated across pages)", len(skills))
+	}
+}
+
+func TestListGlobalSkillsPropagatesCancellationFromList(t *testing.T) {
+	// Cancellation surfacing from the selectable list call itself (not the
+	// per-skill detail fetch) must abort and propagate.
+	m := &mockEnricher{
+		getErrs: map[string]error{"selectable": context.Canceled},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ListGlobalSkills(ctx, m); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled to propagate", err)
+	}
+}
+
+func TestGetAccountEmptyWhenNoGlobalSkills(t *testing.T) {
+	m := &mockEnricher{responses: map[string]string{
+		"selectable": `{"skills":[],"next_cursor":null}`,
+	}}
+
+	account, err := GetAccount(context.Background(), m)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if account == nil {
+		t.Fatal("account is nil, want non-nil with empty skills")
+	}
+	if len(account.GlobalSkills) != 0 {
+		t.Errorf("GlobalSkills = %+v, want empty", account.GlobalSkills)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -114,8 +114,10 @@ type Primer struct {
 //
 // Space-attached skills are fetched via /rest/skills/selectable filtered by
 // collection_uuid. Space-specific skills carry scope=="collection"; global
-// skills carry scope=="global". Full skill detail (including a pre-signed S3
-// file_url for the SKILL.md body) comes from /rest/skills/{id}.
+// (account-wide) skills carry scope=="global". Omitting collection_uuid from
+// the same endpoint returns only the global skills, which are exported once at
+// the account level rather than per space. Full skill detail (including a
+// pre-signed S3 file_url for the SKILL.md body) comes from /rest/skills/{id}.
 
 // SkillsSelectableResponse is the shape of GET /rest/skills/selectable.
 type SkillsSelectableResponse struct {

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -213,6 +213,30 @@ func (e *JSONExporter) ExportUser(user *models.User) error {
 	return writeJSON(filepath.Join(dir, "user.json"), user)
 }
 
+// ExportAccount writes account-wide data (currently global skills).
+//
+// Global skills apply to every request regardless of space, so they are written
+// once under account/ rather than duplicated into each space. Each skill's
+// SKILL.md body is written to account/skills/<name>.md and referenced from
+// account/account.json via body_file.
+func (e *JSONExporter) ExportAccount(account *models.Account) error {
+	if account == nil {
+		return nil
+	}
+	dir := filepath.Join(e.OutputDir, "account")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("could not create account directory: %w", err)
+	}
+
+	// Write skill bodies as sidecar files and record their relative paths
+	// before serializing account.json so body_file is populated.
+	if err := writeSkillBodiesJSON(dir, account.GlobalSkills); err != nil {
+		return err
+	}
+
+	return writeJSON(filepath.Join(dir, "account.json"), account)
+}
+
 // ExportManifest writes the export manifest.
 func (e *JSONExporter) ExportManifest(manifest *models.ExportManifest) error {
 	return writeJSON(filepath.Join(e.OutputDir, "manifest.json"), manifest)
@@ -228,6 +252,15 @@ func (e *JSONExporter) threadDir(thread *models.Thread) string {
 // space.json references it. Skills without a fetched body are left as
 // metadata-only. It mutates the BodyFile field of each skill in place.
 func (e *JSONExporter) writeSpaceSkills(spaceDir string, skills []models.Skill) error {
+	return writeSkillBodiesJSON(spaceDir, skills)
+}
+
+// writeSkillBodiesJSON writes each skill's SKILL.md body into a skills/
+// subfolder of baseDir and records the relative path (skills/<name>.md) on the
+// skill's BodyFile so the sibling JSON references it. Skills without a fetched
+// body are left metadata-only. Filenames are collision-free across the slice.
+// It mutates the BodyFile field of each skill in place.
+func writeSkillBodiesJSON(baseDir string, skills []models.Skill) error {
 	filenames := skillFilenames(skills)
 	var skillsDir string
 	for i := range skills {
@@ -235,7 +268,7 @@ func (e *JSONExporter) writeSpaceSkills(spaceDir string, skills []models.Skill) 
 			continue
 		}
 		if skillsDir == "" {
-			skillsDir = filepath.Join(spaceDir, "skills")
+			skillsDir = filepath.Join(baseDir, "skills")
 			if err := os.MkdirAll(skillsDir, 0755); err != nil {
 				return fmt.Errorf("could not create skills directory: %w", err)
 			}

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -169,3 +169,79 @@ func TestWriteJSONFailedWriteLeavesExistingFileIntact(t *testing.T) {
 		}
 	}
 }
+
+func TestExportAccountWritesGlobalSkills(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+
+	account := &models.Account{
+		GlobalSkills: []models.Skill{
+			{
+				ID:    "g1",
+				Name:  "create-skill",
+				Scope: "global",
+				Body:  "---\nname: create-skill\n---\nGlobal body",
+			},
+			{
+				ID:    "g2",
+				Name:  "no-body-skill",
+				Scope: "global",
+				// No Body — metadata only, must not produce a file.
+			},
+		},
+	}
+
+	if err := exporter.ExportAccount(account); err != nil {
+		t.Fatalf("ExportAccount: %v", err)
+	}
+
+	accountDir := filepath.Join(dir, "account")
+
+	// The skill body file must exist under account/skills/.
+	body, err := os.ReadFile(filepath.Join(accountDir, "skills", "create-skill.md"))
+	if err != nil {
+		t.Fatalf("read skill body: %v", err)
+	}
+	if !strings.Contains(string(body), "Global body") {
+		t.Errorf("skill body = %q, want fetched SKILL.md", string(body))
+	}
+
+	// The body-less skill must not create a file.
+	if _, err := os.Stat(filepath.Join(accountDir, "skills", "no-body-skill.md")); !os.IsNotExist(err) {
+		t.Errorf("body-less skill produced a file, want none (err=%v)", err)
+	}
+
+	// account.json must carry skills metadata with body_file set on the one
+	// that has a body, and must not leak the body content.
+	raw, err := os.ReadFile(filepath.Join(accountDir, "account.json"))
+	if err != nil {
+		t.Fatalf("read account.json: %v", err)
+	}
+	var written models.Account
+	if err := json.Unmarshal(raw, &written); err != nil {
+		t.Fatalf("unmarshal account.json: %v", err)
+	}
+	if len(written.GlobalSkills) != 2 {
+		t.Fatalf("got %d global skills, want 2", len(written.GlobalSkills))
+	}
+	if written.GlobalSkills[0].BodyFile != "skills/create-skill.md" {
+		t.Errorf("BodyFile = %q, want skills/create-skill.md", written.GlobalSkills[0].BodyFile)
+	}
+	if written.GlobalSkills[1].BodyFile != "" {
+		t.Errorf("body-less skill BodyFile = %q, want empty", written.GlobalSkills[1].BodyFile)
+	}
+	if strings.Contains(string(raw), "Global body") {
+		t.Error("account.json leaked the skill body; Body should be json:\"-\"")
+	}
+}
+
+func TestExportAccountNilIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	if err := exporter.ExportAccount(nil); err != nil {
+		t.Fatalf("ExportAccount(nil): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "account")); !os.IsNotExist(err) {
+		t.Errorf("nil account created an account dir (err=%v)", err)
+	}
+}

--- a/internal/export/markdown.go
+++ b/internal/export/markdown.go
@@ -201,8 +201,10 @@ func (e *MarkdownExporter) ExportSpaces(ctx context.Context, spaces []models.Spa
 }
 
 // writeSpaceSkillBodies writes each skill's SKILL.md body into a skills/
-// subfolder of the space directory. Skills without a fetched body are skipped.
-func writeSpaceSkillBodies(spaceDir string, skills []models.Skill) error {
+// subfolder of baseDir (a space or the account directory). Skills without a
+// fetched body are skipped. Filenames are collision-free across the slice and
+// agree with the links written by the caller.
+func writeSpaceSkillBodies(baseDir string, skills []models.Skill) error {
 	filenames := skillFilenames(skills)
 	var skillsDir string
 	for i := range skills {
@@ -210,7 +212,7 @@ func writeSpaceSkillBodies(spaceDir string, skills []models.Skill) error {
 			continue
 		}
 		if skillsDir == "" {
-			skillsDir = filepath.Join(spaceDir, "skills")
+			skillsDir = filepath.Join(baseDir, "skills")
 			if err := os.MkdirAll(skillsDir, 0755); err != nil {
 				return fmt.Errorf("could not create skills directory: %w", err)
 			}
@@ -244,6 +246,56 @@ func (e *MarkdownExporter) ExportUser(user *models.User) error {
 		return fmt.Errorf("could not write profile markdown: %w", err)
 	}
 
+	return nil
+}
+
+// ExportAccount writes account-wide data (currently global skills) as Markdown.
+//
+// Global skills apply to every request regardless of space, so they are written
+// once under account/ rather than per space. Bodies go to account/skills/ and
+// account/global-skills.md links to them.
+func (e *MarkdownExporter) ExportAccount(account *models.Account) error {
+	if account == nil {
+		return nil
+	}
+	dir := filepath.Join(e.OutputDir, "account")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("could not create account directory: %w", err)
+	}
+
+	// Write skill bodies first so the links below point at real files.
+	if err := writeSpaceSkillBodies(dir, account.GlobalSkills); err != nil {
+		return err
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Global Skills\n\n")
+	sb.WriteString("Account-wide skills applied to every request, regardless of space.\n\n")
+
+	if len(account.GlobalSkills) == 0 {
+		sb.WriteString("_No global skills._\n")
+	} else {
+		filenames := skillFilenames(account.GlobalSkills)
+		for i, sk := range account.GlobalSkills {
+			if sk.Body != "" {
+				// Link relative to global-skills.md, which lives in the account
+				// dir. path.Join keeps forward slashes for portable Markdown.
+				link := path.Join("skills", filenames[i])
+				sb.WriteString(fmt.Sprintf("- [%s](%s)", sk.Name, link))
+			} else {
+				sb.WriteString(fmt.Sprintf("- %s", sk.Name))
+			}
+			if sk.Description != "" {
+				sb.WriteString(fmt.Sprintf(" — %s", sk.Description))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	out := filepath.Join(dir, "global-skills.md")
+	if err := os.WriteFile(out, []byte(sb.String()), 0644); err != nil {
+		return fmt.Errorf("could not write global skills markdown: %w", err)
+	}
 	return nil
 }
 

--- a/internal/export/markdown_test.go
+++ b/internal/export/markdown_test.go
@@ -165,3 +165,82 @@ func TestMarkdownExportSpacesMultilineInstructions(t *testing.T) {
 		t.Errorf("multiline instructions not blockquoted per line\n%s", content)
 	}
 }
+
+func TestMarkdownExportAccountWritesGlobalSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+	exp := &MarkdownExporter{OutputDir: tmpDir}
+
+	account := &models.Account{
+		GlobalSkills: []models.Skill{
+			// Body-backed skill: gets a sidecar file and a link.
+			{ID: "g1", Name: "create-skill", Description: "Create skills", Body: "# create-skill\nbody"},
+			// Metadata-only skill: rendered inline, no link, no file.
+			{ID: "g2", Name: "no-body", Description: "No body here"},
+		},
+	}
+
+	if err := exp.ExportAccount(account); err != nil {
+		t.Fatalf("ExportAccount: %v", err)
+	}
+
+	overview, err := os.ReadFile(filepath.Join(tmpDir, "account", "global-skills.md"))
+	if err != nil {
+		t.Fatalf("read global-skills.md: %v", err)
+	}
+	content := string(overview)
+
+	// Link uses forward slashes and the collision-free filename, relative to
+	// global-skills.md (which lives in account/).
+	wantLink := "[create-skill](skills/create-skill.md)"
+	if !strings.Contains(content, wantLink) {
+		t.Errorf("global-skills.md missing skill link %q\n%s", wantLink, content)
+	}
+	// Metadata-only skill is present but not linked.
+	if !strings.Contains(content, "- no-body — No body here") {
+		t.Errorf("global-skills.md missing metadata-only skill line\n%s", content)
+	}
+	if strings.Contains(content, "no-body.md") {
+		t.Errorf("global-skills.md should not link a body-less skill\n%s", content)
+	}
+
+	// The body sidecar exists under account/skills/.
+	body, err := os.ReadFile(filepath.Join(tmpDir, "account", "skills", "create-skill.md"))
+	if err != nil {
+		t.Fatalf("read skill body: %v", err)
+	}
+	if string(body) != "# create-skill\nbody" {
+		t.Errorf("skill body = %q, want fetched SKILL.md", string(body))
+	}
+
+	// The body-less skill must not produce a sidecar file.
+	if _, err := os.Stat(filepath.Join(tmpDir, "account", "skills", "no-body.md")); !os.IsNotExist(err) {
+		t.Errorf("unexpected sidecar for body-less skill (err=%v)", err)
+	}
+}
+
+func TestMarkdownExportAccountEmptyAndNil(t *testing.T) {
+	tmpDir := t.TempDir()
+	exp := &MarkdownExporter{OutputDir: tmpDir}
+
+	// Empty global-skills set still writes the overview with a placeholder.
+	if err := exp.ExportAccount(&models.Account{}); err != nil {
+		t.Fatalf("ExportAccount(empty): %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(tmpDir, "account", "global-skills.md"))
+	if err != nil {
+		t.Fatalf("read global-skills.md: %v", err)
+	}
+	if !strings.Contains(string(content), "_No global skills._") {
+		t.Errorf("empty account missing placeholder\n%s", content)
+	}
+
+	// Nil account is a no-op: it must not create the account dir.
+	tmpDir2 := t.TempDir()
+	exp2 := &MarkdownExporter{OutputDir: tmpDir2}
+	if err := exp2.ExportAccount(nil); err != nil {
+		t.Fatalf("ExportAccount(nil): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir2, "account")); !os.IsNotExist(err) {
+		t.Errorf("nil account created an account dir (err=%v)", err)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -107,6 +107,18 @@ type Skill struct {
 	Body string `json:"-"`
 }
 
+// Account holds account-wide data that applies across all spaces and requests,
+// as opposed to Space-scoped configuration. It is a container so future
+// account-wide resources (settings, connectors, rate limits) can be added
+// without reshaping the export surface.
+type Account struct {
+	// GlobalSkills are account-wide skills (scope == "global") applied to every
+	// request regardless of space, unlike Space.Skills which are collection
+	// scoped. Bodies are fetched during listing and written to sidecar files by
+	// the exporters; they are not embedded in JSON.
+	GlobalSkills []Skill `json:"global_skills,omitempty"`
+}
+
 // ExportManifest holds metadata about an export run.
 type ExportManifest struct {
 	Version     string            `json:"version"`
@@ -118,10 +130,11 @@ type ExportManifest struct {
 
 // ExportCounts holds the number of each item type exported.
 type ExportCounts struct {
-	Threads   int `json:"threads"`
-	Spaces    int `json:"spaces"`
-	Bookmarks int `json:"bookmarks"`
-	Sources   int `json:"sources"`
+	Threads      int `json:"threads"`
+	Spaces       int `json:"spaces"`
+	Bookmarks    int `json:"bookmarks"`
+	Sources      int `json:"sources"`
+	GlobalSkills int `json:"global_skills"`
 }
 
 // ThreadIndex holds the cached list of thread UUIDs for resumable export.


### PR DESCRIPTION
## Description

Perplexity "global" skills (`scope=="global"`) apply to every request regardless of space, so they belong at the account level rather than duplicated inside each space folder. This is a follow-up to #62 (space instructions + attached skills).

This PR:
- Adds `GET /rest/skills/selectable` with **no** `collection_uuid`, which the API treats as an account-wide listing returning only global-scoped skills.
- Wraps them in a new `models.Account` so future account-scoped data has a home.
- Exports them **once** under `account/`: `account.json` (JSON), `global-skills.md` (Markdown), and each `SKILL.md` body under `account/skills/<name>.md`.
- Extracts per-skill enrichment (detail fetch + body download) into a shared `enrichSkill` helper used by both the space and global paths.
- Deduplicates the global list by skill ID across pagination pages.

Fetching is fail-soft (a non-cancellation error skips the section; context cancellation aborts the export) and is gated behind `--spaces`, so `--no-spaces` suppresses all skill fetching consistently.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes (5/5 targets)
- [x] `go test ./...` passes
- [x] Unit tests added: API (`skills_test.go`: global filtering, fail-soft on detail/body errors, cancellation from both list and detail, pagination dedup, empty/omit `collection_uuid`), exporters (`account/` JSON + Markdown output, nil/empty account no-op, body-less skills, portable paths/links), and command gating (`exportFormat` writes no `account/` when account is nil).

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (new Go files added)
- [x] No secrets or credentials introduced
- [x] Documentation updated (`AGENTS.md`: endpoint table, export flow, `skills.go` module note)

## Release Notes

Global skills are now exported once under `account/` (`account.json`, `global-skills.md`, `account/skills/<name>.md`) instead of being duplicated per space.

## Additional Context

- Reviewed by `code-reviewer` and `change-validator`; the `--no-spaces` gating gap they flagged is fixed and a regression test added.
- Known limitation (consistent with the existing profile behavior): `--format pdf` alone writes no `account/` output, since the PDF path has no sidecar mechanism for skill bodies. Use `json` or `markdown` to capture global skills.