### PR TITLE
fix: report incomplete thread exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Answer content is in `entries[].blocks[]` where `intended_usage == "ask_text_0_m
 ## Export Flow
 
 1. **Phase 1 — Index**: `POST /rest/thread/list_ask_threads` with pagination (limit=20, ascending=false). Dual stop condition: `len(response) < limit` (primary) + all-duplicates (safety net). Result cached in `thread_index.json` with `Complete: true` flag.
-2. **Phase 2 — Details**: `GET /rest/thread/{uuid}` for each thread. Skips threads already fetched on disk. Adaptive rate limiting: delay doubles after 429, halves after 20 consecutive successes.
+2. **Phase 2 — Details**: `GET /rest/thread/{uuid}` for each thread. Skips threads already fetched on disk. Ordinary per-thread fetch/write failures preserve and render successful threads, but `manifest.json` records `threads_complete: false`, `expected_threads`, and ordered `failed_threads`, and the command exits non-zero after writing the manifest. Cancellation/deadline errors abort immediately and take precedence over accumulated failures. A failed `--refresh` must not count a stale cached thread as a current success. Adaptive rate limiting: delay doubles after 429, halves after 20 consecutive successes.
 3. **Phase 3 — Render**: Convert domain models to JSON/Markdown/PDF. Write threads to `threads/<slug>/` (canonical flat list). Copy thread files into `spaces/<name>/threads/<slug>/` so each space folder is self-contained. Account-wide global skills are written **once** under `account/`: `account/account.json` (JSON) + `account/global-skills.md` (Markdown), with each skill body in `account/skills/<name>.md`. They are not duplicated per space.
 
 Use `--refresh` to force re-fetching the thread index.

--- a/README.md
+++ b/README.md
@@ -119,11 +119,17 @@ Export runs in two phases:
 
 Use `--refresh` to force re-fetching the thread index (e.g., after new conversations).
 
+If one or more thread details cannot be fetched or written after retries, Deplexity
+keeps and renders every thread that completed successfully, writes the failure
+details to `manifest.json`, and exits with a non-zero status. Re-run the same export
+command to retry the missing threads from the saved checkpoints. A cancelled export
+stops immediately instead of being reported as a partial success.
+
 ### Output Structure
 
 ```
 deplexity-export/
-├── manifest.json              # Export metadata (timestamp, counts, version)
+├── manifest.json              # Export metadata, thread completeness, and failures
 ├── thread_index.json          # Cached thread list (for resumable exports)
 ├── profile/
 │   └── user.json
@@ -158,6 +164,11 @@ Each space folder is self-contained — you can ZIP and share a single space wit
 Space exports capture each space's full context: its custom AI instructions, description, suggested queries, primers, and any attached skills. Skill definitions are written as `SKILL.md` files under `spaces/<space-name>/skills/` and referenced from `space.json`.
 
 Account-wide **global skills** apply to every request regardless of space, so they are exported once under `account/` rather than duplicated per space. They are captured when spaces are exported (skip them with `--no-spaces`) and are written to JSON and Markdown outputs (`account/account.json`, `account/global-skills.md`, and bodies under `account/skills/`); PDF-only exports do not include them.
+
+For automation, `manifest.json` reports `threads_complete`, `expected_threads`,
+and `failed_threads`. Each failure includes its thread UUID, optional title, stage
+(`fetch`, `write`, or `load`), and error message. `counts.threads` remains the
+number of threads present in the current export.
 
 ---
 

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -28,6 +28,8 @@ var (
 	buildTime = "unknown"
 )
 
+var errIncompleteThreadExport = errors.New("thread export incomplete")
+
 // CLI defines the top-level command structure.
 type CLI struct {
 	Verbose bool       `short:"v" help:"Enable verbose/debug output."`
@@ -118,8 +120,19 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 
 	// === Phase 2: Fetch thread details (resumable) ===
 	var threads []models.Thread
+	var threadFailures []models.ThreadExportFailure
 	if cmd.Threads && len(threadRefs) > 0 {
-		threads, err = cmd.fetchThreadDetails(ctx, c, jsonExp, threadRefs)
+		getThread := func(ctx context.Context, uuid string, resume *models.Thread, onPage func(*models.Thread) error) (*models.Thread, error) {
+			return api.GetThread(ctx, c, uuid, resume, onPage)
+		}
+		threads, threadFailures, err = cmd.fetchThreadDetails(ctx, jsonExp, threadRefs, getThread)
+		if persistErr := persistThreadRetryState(jsonExp, threadRefs); persistErr != nil {
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not save thread retry state: %v\n", persistErr)
+			} else {
+				return persistErr
+			}
+		}
 		if err != nil {
 			return err
 		}
@@ -196,11 +209,36 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	// Write manifest
+	// Write the manifest before reporting a partial thread failure so successful
+	// output remains usable and the incomplete run is machine-detectable.
+	manifest := buildManifest(cmd.Format, threads, spaces, account, len(threadRefs), threadFailures)
+
+	if err := finalizeExport(jsonExp, manifest); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nExport complete: %s (%s)\n", cmd.Output, time.Since(startTime).Round(time.Second))
+	return nil
+}
+
+func finalizeExport(jsonExp *export.JSONExporter, manifest *models.ExportManifest) error {
+	if err := jsonExp.ExportManifest(manifest); err != nil {
+		return err
+	}
+	if len(manifest.FailedThreads) > 0 {
+		return fmt.Errorf("%w: %d of %d threads failed; re-run the same command to resume", errIncompleteThreadExport, len(manifest.FailedThreads), manifest.ExpectedThreads)
+	}
+	return nil
+}
+
+func buildManifest(formats []string, threads []models.Thread, spaces []models.Space, account *models.Account, expectedThreads int, failures []models.ThreadExportFailure) *models.ExportManifest {
 	manifest := &models.ExportManifest{
-		Version:    version,
-		ExportedAt: time.Now().UTC(),
-		Formats:    cmd.Format,
+		Version:         version,
+		ExportedAt:      time.Now().UTC(),
+		Formats:         formats,
+		ThreadsComplete: len(failures) == 0,
+		ExpectedThreads: expectedThreads,
+		FailedThreads:   failures,
 		Counts: models.ExportCounts{
 			Threads: len(threads),
 			Spaces:  len(spaces),
@@ -216,12 +254,30 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 			manifest.Counts.Sources += len(e.Sources)
 		}
 	}
+	return manifest
+}
 
-	if err := jsonExp.ExportManifest(manifest); err != nil {
-		return err
+func persistThreadRetryState(jsonExp *export.JSONExporter, refs []models.ThreadRef) error {
+	index, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		return fmt.Errorf("could not load thread index to save retry state: %w", err)
+	}
+	if index == nil {
+		return errors.New("could not save thread retry state: thread index is missing")
 	}
 
-	fmt.Printf("\nExport complete: %s (%s)\n", cmd.Output, time.Since(startTime).Round(time.Second))
+	retryByUUID := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		retryByUUID[ref.UUID] = ref.RetryRequired
+	}
+	for i := range index.Threads {
+		if retry, ok := retryByUUID[index.Threads[i].UUID]; ok {
+			index.Threads[i].RetryRequired = retry
+		}
+	}
+	if err := jsonExp.SaveThreadIndex(index); err != nil {
+		return fmt.Errorf("could not save thread retry state: %w", err)
+	}
 	return nil
 }
 
@@ -348,14 +404,18 @@ func buildRefsFromThreads(threads []models.Thread) []models.ThreadRef {
 	return refs
 }
 
+type getThreadFunc func(context.Context, string, *models.Thread, func(*models.Thread) error) (*models.Thread, error)
+
 // fetchThreadDetails fetches full details for incomplete or changed threads.
-func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, jsonExp *export.JSONExporter, refs []models.ThreadRef) ([]models.Thread, error) {
+func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, jsonExp *export.JSONExporter, refs []models.ThreadRef, getThread getThreadFunc) ([]models.Thread, []models.ThreadExportFailure, error) {
 	// Determine which threads need fetching
-	var missing []models.ThreadRef
-	for _, ref := range refs {
+	var missing []int
+	failuresByUUID := make(map[string]models.ThreadExportFailure)
+	for i, ref := range refs {
 		cached, err := jsonExp.LoadCompleteThread(ref.UUID)
 		if needsThreadFetch(cmd.Refresh, ref, cached, err) {
-			missing = append(missing, ref)
+			missing = append(missing, i)
+			refs[i].RetryRequired = true
 		}
 	}
 
@@ -367,11 +427,12 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 			progressbar.OptionSetWidth(40),
 		)
 
-		for _, ref := range missing {
+		for _, refIndex := range missing {
+			ref := &refs[refIndex]
 			select {
 			case <-ctx.Done():
 				fmt.Printf("\nInterrupted. Progress saved — resume by running the same command.\n")
-				return nil, ctx.Err()
+				return nil, orderedThreadFailures(refs, failuresByUUID), ctx.Err()
 			default:
 			}
 
@@ -386,9 +447,13 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 
 			onPage := func(t *models.Thread) error { return jsonExp.ExportThread(t) }
 
-			full, err := api.GetThread(ctx, c, ref.UUID, resume, onPage)
+			full, err := getThread(ctx, ref.UUID, resume, onPage)
 			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil, orderedThreadFailures(refs, failuresByUUID), err
+				}
 				fmt.Fprintf(os.Stderr, "\n  Warning: could not fetch thread %s: %v\n", ref.UUID, err)
+				failuresByUUID[ref.UUID] = models.ThreadExportFailure{UUID: ref.UUID, Title: ref.Title, Stage: models.ThreadExportStageFetch, Error: err.Error()}
 				_ = bar.Add(1)
 				continue
 			}
@@ -396,6 +461,9 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 			// Write to disk immediately
 			if err := jsonExp.ExportThread(full); err != nil {
 				fmt.Fprintf(os.Stderr, "\n  Warning: could not write thread %s: %v\n", ref.UUID, err)
+				failuresByUUID[ref.UUID] = models.ThreadExportFailure{UUID: ref.UUID, Title: ref.Title, Stage: models.ThreadExportStageWrite, Error: err.Error()}
+			} else {
+				ref.RetryRequired = false
 			}
 			_ = bar.Add(1)
 		}
@@ -406,15 +474,30 @@ func (cmd *ExportCmd) fetchThreadDetails(ctx context.Context, c *client.Client, 
 
 	// Load all threads from disk
 	threads := make([]models.Thread, 0, len(refs))
-	for _, ref := range refs {
+	for i, ref := range refs {
+		if _, failed := failuresByUUID[ref.UUID]; failed {
+			continue
+		}
 		t, err := jsonExp.LoadCompleteThread(ref.UUID)
 		if err != nil {
-			continue // skip threads that failed to fetch
+			failuresByUUID[ref.UUID] = models.ThreadExportFailure{UUID: ref.UUID, Title: ref.Title, Stage: models.ThreadExportStageLoad, Error: err.Error()}
+			refs[i].RetryRequired = true
+			continue
 		}
 		threads = append(threads, *t)
 	}
 
-	return threads, nil
+	return threads, orderedThreadFailures(refs, failuresByUUID), nil
+}
+
+func orderedThreadFailures(refs []models.ThreadRef, failuresByUUID map[string]models.ThreadExportFailure) []models.ThreadExportFailure {
+	failures := make([]models.ThreadExportFailure, 0, len(failuresByUUID))
+	for _, ref := range refs {
+		if failure, ok := failuresByUUID[ref.UUID]; ok {
+			failures = append(failures, failure)
+		}
+	}
+	return failures
 }
 
 // resumePoint reports the checkpoint an interrupted fetch should continue
@@ -428,19 +511,21 @@ func resumePoint(refresh bool, partial *models.Thread) *models.Thread {
 }
 
 func needsThreadFetch(refresh bool, ref models.ThreadRef, cached *models.Thread, err error) bool {
-	if err != nil || cached == nil {
+	if ref.RetryRequired || err != nil || cached == nil {
 		return true
 	}
 	return refresh && (ref.UpdatedAt.IsZero() || ref.PreviousUpdatedAt.IsZero() || ref.UpdatedAt.After(ref.PreviousUpdatedAt))
 }
 
 func attachPreviousUpdatedAt(refs []models.ThreadRef, previous []models.ThreadRef) {
-	previousByUUID := make(map[string]time.Time, len(previous))
+	previousByUUID := make(map[string]models.ThreadRef, len(previous))
 	for _, ref := range previous {
-		previousByUUID[ref.UUID] = ref.UpdatedAt
+		previousByUUID[ref.UUID] = ref
 	}
 	for i := range refs {
-		refs[i].PreviousUpdatedAt = previousByUUID[refs[i].UUID]
+		previousRef := previousByUUID[refs[i].UUID]
+		refs[i].PreviousUpdatedAt = previousRef.UpdatedAt
+		refs[i].RetryRequired = previousRef.RetryRequired
 	}
 }
 

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,5 +180,271 @@ func TestExportFormatAccountGating(t *testing.T) {
 				t.Errorf("non-nil account produced no account/ output: %v", err)
 			}
 		})
+	}
+}
+
+func TestFetchThreadDetailsTracksFailuresAndKeepsSuccessfulThreads(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	refs := []models.ThreadRef{
+		{UUID: "thread-1", Title: "First"},
+		{UUID: "thread-2", Title: "Second"},
+		{UUID: "thread-3", Title: "Third"},
+	}
+	fetch := func(_ context.Context, uuid string, _ *models.Thread, _ func(*models.Thread) error) (*models.Thread, error) {
+		if uuid == "thread-2" {
+			return nil, errors.New("upstream failure")
+		}
+		return &models.Thread{UUID: uuid, Slug: uuid, Complete: true}, nil
+	}
+
+	cmd := &ExportCmd{}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if err != nil {
+		t.Fatalf("fetchThreadDetails: %v", err)
+	}
+	if len(threads) != 2 || threads[0].UUID != "thread-1" || threads[1].UUID != "thread-3" {
+		t.Fatalf("threads = %#v, want successful threads in reference order", threads)
+	}
+	if len(failures) != 1 {
+		t.Fatalf("failures = %#v, want one failure", failures)
+	}
+	if failures[0].UUID != "thread-2" || failures[0].Title != "Second" || failures[0].Stage != models.ThreadExportStageFetch {
+		t.Errorf("failure = %#v, want thread-2 fetch failure", failures[0])
+	}
+}
+
+func TestFetchThreadDetailsTracksFinalWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "threads"), []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+	jsonExp := &export.JSONExporter{OutputDir: dir}
+	refs := []models.ThreadRef{{UUID: "thread-1", Title: "First"}}
+	fetch := func(_ context.Context, uuid string, _ *models.Thread, _ func(*models.Thread) error) (*models.Thread, error) {
+		return &models.Thread{UUID: uuid, Slug: uuid, Complete: true}, nil
+	}
+
+	cmd := &ExportCmd{}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if err != nil {
+		t.Fatalf("fetchThreadDetails: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("got %d successful threads, want none", len(threads))
+	}
+	if len(failures) != 1 || failures[0].UUID != "thread-1" || failures[0].Stage != models.ThreadExportStageWrite {
+		t.Fatalf("failures = %#v, want thread-1 write failure", failures)
+	}
+}
+
+func TestFetchThreadDetailsTracksCheckpointFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "threads"), []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+	jsonExp := &export.JSONExporter{OutputDir: dir}
+	refs := []models.ThreadRef{{UUID: "thread-1", Title: "First"}}
+	fetch := func(_ context.Context, uuid string, _ *models.Thread, onPage func(*models.Thread) error) (*models.Thread, error) {
+		partial := &models.Thread{UUID: uuid, Slug: uuid, NextCursor: "next"}
+		if err := onPage(partial); err != nil {
+			return nil, fmt.Errorf("checkpoint failed: %w", err)
+		}
+		return nil, errors.New("checkpoint unexpectedly succeeded")
+	}
+
+	cmd := &ExportCmd{}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if err != nil {
+		t.Fatalf("fetchThreadDetails: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("got %d successful threads, want none", len(threads))
+	}
+	if len(failures) != 1 || failures[0].UUID != "thread-1" || failures[0].Stage != models.ThreadExportStageFetch {
+		t.Fatalf("failures = %#v, want checkpoint failure recorded for thread-1", failures)
+	}
+}
+
+func TestFetchThreadDetailsFailedRefreshDoesNotUseStaleCache(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	oldUpdatedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	stale := &models.Thread{UUID: "thread-1", Slug: "thread-1", UpdatedAt: oldUpdatedAt, Complete: true}
+	if err := jsonExp.ExportThread(stale); err != nil {
+		t.Fatalf("seed stale thread: %v", err)
+	}
+	refs := []models.ThreadRef{{
+		UUID:              "thread-1",
+		Title:             "First",
+		UpdatedAt:         oldUpdatedAt.Add(time.Hour),
+		PreviousUpdatedAt: oldUpdatedAt,
+	}}
+	fetch := func(context.Context, string, *models.Thread, func(*models.Thread) error) (*models.Thread, error) {
+		return nil, errors.New("refresh failed")
+	}
+
+	cmd := &ExportCmd{Refresh: true}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if err != nil {
+		t.Fatalf("fetchThreadDetails: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("stale cached thread counted as successful: %#v", threads)
+	}
+	if len(failures) != 1 || failures[0].UUID != "thread-1" {
+		t.Fatalf("failures = %#v, want failed refresh", failures)
+	}
+}
+
+func TestFetchThreadDetailsCancellationTakesPrecedence(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	refs := []models.ThreadRef{{UUID: "thread-1"}, {UUID: "thread-2"}}
+	fetch := func(_ context.Context, uuid string, _ *models.Thread, _ func(*models.Thread) error) (*models.Thread, error) {
+		if uuid == "thread-1" {
+			return nil, errors.New("ordinary failure")
+		}
+		return nil, fmt.Errorf("fetch stopped: %w", context.Canceled)
+	}
+
+	cmd := &ExportCmd{}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if threads != nil {
+		t.Fatalf("threads=%#v, want cancellation to abort successful result", threads)
+	}
+	if len(failures) != 1 || failures[0].UUID != "thread-1" {
+		t.Fatalf("failures=%#v, want prior failure preserved for retry state", failures)
+	}
+}
+
+func TestNeedsThreadFetchHonorsPersistedRetry(t *testing.T) {
+	cached := &models.Thread{Complete: true}
+	ref := models.ThreadRef{UUID: "thread-1", RetryRequired: true}
+	if !needsThreadFetch(false, ref, cached, nil) {
+		t.Fatal("needsThreadFetch = false, want persisted retry to force fetch")
+	}
+}
+
+func TestPersistThreadRetryStateRoundTrips(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	index := &models.ThreadIndex{
+		Threads:  []models.ThreadRef{{UUID: "thread-1"}, {UUID: "thread-2", RetryRequired: true}},
+		Total:    2,
+		Complete: true,
+	}
+	if err := jsonExp.SaveThreadIndex(index); err != nil {
+		t.Fatalf("SaveThreadIndex: %v", err)
+	}
+	refs := []models.ThreadRef{{UUID: "thread-1", RetryRequired: true}, {UUID: "thread-2"}}
+	if err := persistThreadRetryState(jsonExp, refs); err != nil {
+		t.Fatalf("persistThreadRetryState: %v", err)
+	}
+
+	reloaded, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		t.Fatalf("LoadThreadIndex: %v", err)
+	}
+	if !reloaded.Threads[0].RetryRequired || reloaded.Threads[1].RetryRequired {
+		t.Fatalf("retry state = %#v, want thread-1 only", reloaded.Threads)
+	}
+}
+
+func TestFetchThreadDetailsPreCancelledContext(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	fetch := func(context.Context, string, *models.Thread, func(*models.Thread) error) (*models.Thread, error) {
+		called = true
+		return nil, nil
+	}
+	cmd := &ExportCmd{}
+	_, _, err := cmd.fetchThreadDetails(ctx, jsonExp, []models.ThreadRef{{UUID: "thread-1"}}, fetch)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("fetch called for pre-cancelled context")
+	}
+}
+
+func TestFetchThreadDetailsCancellationPreservesPendingRetryState(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	ctx, cancel := context.WithCancel(context.Background())
+	refs := []models.ThreadRef{{UUID: "thread-1"}, {UUID: "thread-2"}}
+	fetch := func(_ context.Context, uuid string, _ *models.Thread, _ func(*models.Thread) error) (*models.Thread, error) {
+		cancel()
+		return nil, fmt.Errorf("cancel %s: %w", uuid, context.Canceled)
+	}
+
+	cmd := &ExportCmd{}
+	_, _, err := cmd.fetchThreadDetails(ctx, jsonExp, refs, fetch)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if !refs[0].RetryRequired || !refs[1].RetryRequired {
+		t.Fatalf("retry state = %#v, want current and pending threads marked", refs)
+	}
+}
+
+func TestBuildManifestReportsThreadCompleteness(t *testing.T) {
+	threads := []models.Thread{
+		{
+			UUID:     "thread-1",
+			Slug:     "first",
+			Complete: true,
+			Entries:  []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+		},
+	}
+	failures := []models.ThreadExportFailure{{UUID: "thread-2", Stage: models.ThreadExportStageFetch, Error: "failed"}}
+	account := &models.Account{GlobalSkills: []models.Skill{{ID: "skill-1"}}}
+
+	manifest := buildManifest([]string{"json"}, threads, []models.Space{{UUID: "space-1"}}, account, 2, failures)
+	if manifest.ThreadsComplete {
+		t.Fatal("ThreadsComplete = true, want false")
+	}
+	if manifest.ExpectedThreads != 2 || manifest.Counts.Threads != 1 {
+		t.Errorf("expected=%d exported=%d, want 2 and 1", manifest.ExpectedThreads, manifest.Counts.Threads)
+	}
+	if manifest.Counts.Spaces != 1 || manifest.Counts.Sources != 1 || manifest.Counts.GlobalSkills != 1 {
+		t.Errorf("counts = %#v, want one space, source, and global skill", manifest.Counts)
+	}
+	if len(manifest.FailedThreads) != 1 || manifest.FailedThreads[0].UUID != "thread-2" {
+		t.Errorf("FailedThreads = %#v, want thread-2", manifest.FailedThreads)
+	}
+	if manifest.ThreadIndex["thread-1"] != "first" {
+		t.Errorf("ThreadIndex = %#v, want exported thread", manifest.ThreadIndex)
+	}
+
+	complete := buildManifest([]string{"json"}, nil, nil, nil, 0, nil)
+	if !complete.ThreadsComplete || complete.ExpectedThreads != 0 {
+		t.Errorf("no-thread manifest = %#v, want complete with zero expected threads", complete)
+	}
+}
+
+func TestFinalizeExportWritesPartialManifestBeforeReturningError(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	manifest := &models.ExportManifest{
+		ThreadsComplete: false,
+		ExpectedThreads: 2,
+		FailedThreads: []models.ThreadExportFailure{{
+			UUID:  "thread-2",
+			Stage: models.ThreadExportStageFetch,
+			Error: "failed",
+		}},
+	}
+
+	err := finalizeExport(jsonExp, manifest)
+	if !errors.Is(err, errIncompleteThreadExport) {
+		t.Fatalf("error = %v, want errIncompleteThreadExport", err)
+	}
+	raw, readErr := os.ReadFile(filepath.Join(jsonExp.OutputDir, "manifest.json"))
+	if readErr != nil {
+		t.Fatalf("manifest was not written before error: %v", readErr)
+	}
+	if !strings.Contains(string(raw), `"threads_complete": false`) || !strings.Contains(string(raw), `"uuid": "thread-2"`) {
+		t.Fatalf("manifest = %s, want partial status and failed thread", raw)
 	}
 }

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -77,8 +77,17 @@ func (e *JSONExporter) ExportThread(thread *models.Thread) error {
 		return fmt.Errorf("could not create thread directory: %w", err)
 	}
 
-	// Write thread data
-	if err := writeJSON(filepath.Join(dir, "thread.json"), thread); err != nil {
+	// A complete thread.json is the cache validity marker. Write an incomplete
+	// copy first so a later sidecar failure cannot leave an older complete cache
+	// looking valid, then write the complete marker only after all sidecars.
+	threadPath := filepath.Join(dir, "thread.json")
+	if thread.Complete {
+		incomplete := *thread
+		incomplete.Complete = false
+		if err := writeJSON(threadPath, &incomplete); err != nil {
+			return err
+		}
+	} else if err := writeJSON(threadPath, thread); err != nil {
 		return err
 	}
 
@@ -89,6 +98,11 @@ func (e *JSONExporter) ExportThread(thread *models.Thread) error {
 	}
 	if len(allSources) > 0 {
 		if err := writeJSON(filepath.Join(dir, "sources.json"), allSources); err != nil {
+			return err
+		}
+	}
+	if thread.Complete {
+		if err := writeJSON(threadPath, thread); err != nil {
 			return err
 		}
 	}

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -54,15 +54,44 @@ func TestLoadCompleteThreadPreservesMetadata(t *testing.T) {
 	}
 }
 
+func TestExportThreadMarksCacheIncompleteUntilSidecarsSucceed(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	thread := &models.Thread{
+		UUID:     "thread-1",
+		Slug:     "thread-1",
+		Complete: true,
+		Entries:  []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+	}
+	threadDir := exporter.threadDir(thread)
+	if err := os.MkdirAll(filepath.Join(threadDir, "sources.json"), 0755); err != nil {
+		t.Fatalf("create blocking sources directory: %v", err)
+	}
+
+	if err := exporter.ExportThread(thread); err == nil {
+		t.Fatal("ExportThread succeeded with blocked sources.json")
+	}
+	if _, err := exporter.LoadCompleteThread(thread.UUID); err == nil {
+		t.Fatal("LoadCompleteThread accepted cache after sidecar write failure")
+	}
+	partial, err := exporter.LoadThread(thread.UUID)
+	if err != nil {
+		t.Fatalf("LoadThread: %v", err)
+	}
+	if partial.Complete {
+		t.Fatal("thread.json remains complete after sidecar write failure")
+	}
+}
+
 func TestExportSpacesWritesInstructionsAndSkills(t *testing.T) {
 	dir := t.TempDir()
 	exporter := &JSONExporter{OutputDir: dir}
 
 	space := models.Space{
-		UUID:         "e79179d1",
-		Name:         "Recipes",
-		Slug:         "recipes-55F50RUIQUK_fqfJUieN1w",
-		Instructions: "Test for the deplexity tool",
+		UUID:             "e79179d1",
+		Name:             "Recipes",
+		Slug:             "recipes-55F50RUIQUK_fqfJUieN1w",
+		Instructions:     "Test for the deplexity tool",
 		SuggestedQueries: []string{"How do I sear steak?"},
 		Skills: []models.Skill{
 			{

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -121,12 +121,29 @@ type Account struct {
 
 // ExportManifest holds metadata about an export run.
 type ExportManifest struct {
-	Version     string            `json:"version"`
-	ExportedAt  time.Time         `json:"exported_at"`
-	Formats     []string          `json:"formats"`
-	Counts      ExportCounts      `json:"counts"`
-	ThreadIndex map[string]string `json:"thread_index,omitempty"` // uuid -> slug
+	Version         string                `json:"version"`
+	ExportedAt      time.Time             `json:"exported_at"`
+	Formats         []string              `json:"formats"`
+	Counts          ExportCounts          `json:"counts"`
+	ThreadsComplete bool                  `json:"threads_complete"`
+	ExpectedThreads int                   `json:"expected_threads"`
+	FailedThreads   []ThreadExportFailure `json:"failed_threads,omitempty"`
+	ThreadIndex     map[string]string     `json:"thread_index,omitempty"` // uuid -> slug
 }
+
+// ThreadExportFailure identifies a thread that could not be exported during a run.
+type ThreadExportFailure struct {
+	UUID  string `json:"uuid"`
+	Title string `json:"title,omitempty"`
+	Stage string `json:"stage"`
+	Error string `json:"error"`
+}
+
+const (
+	ThreadExportStageFetch = "fetch"
+	ThreadExportStageWrite = "write"
+	ThreadExportStageLoad  = "load"
+)
 
 // ExportCounts holds the number of each item type exported.
 type ExportCounts struct {
@@ -151,6 +168,7 @@ type ThreadRef struct {
 	Title             string    `json:"title"`
 	SpaceUUID         string    `json:"space_uuid,omitempty"`
 	UpdatedAt         time.Time `json:"updated_at"`
+	RetryRequired     bool      `json:"retry_required,omitempty"`
 	PreviousUpdatedAt time.Time `json:"-"`
 }
 


### PR DESCRIPTION
## Description

Preserve every successfully exported thread while making partial thread failures explicit and machine-detectable.

The export manifest now records thread completeness, the expected thread count, and ordered fetch/write/load failures. Incomplete exports write all usable output and the manifest before returning a non-zero status. Retry intent is persisted in `thread_index.json`, so failed refreshes and interrupted runs cannot be hidden by stale complete cache data. Complete thread JSON is written only after its sidecar artifacts succeed.

This fixes the previous behavior where thread fetch or write failures were logged and skipped before the command printed `Export complete` and exited successfully.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go vet ./...`, `go test -race ./...`, and `bazel build //cmd/deplexity` pass;

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Incomplete thread exports now preserve successful output while recording failed threads in `manifest.json` and returning a non-zero exit status. Failed refreshes and interrupted exports retain retry state for subsequent runs.