### PR TITLE
fix: relist incomplete thread indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Binary entrypoint: `cmd/deplexity/main.go`. Version/buildTime stamped via `x_def
 ## Architecture
 
 - `internal/api/types.go` — **raw API response structs** (JSON tags match Perplexity's undocumented internal API, verified against live responses May 2026, API v2.18).
-- `internal/api/threads.go` — `ListThreads`, `ListThreadsFrom` (POST `list_ask_threads` with pagination, dual stop condition), `GetThread`.
+- `internal/api/threads.go` — `ListThreads` (POST `list_ask_threads` with pagination and dual stop condition), `GetThread`.
 - `internal/api/collections.go` — `ListCollections` via `GET /rest/spaces`, then always-on fail-soft enrichment: `GetCollection` (per-space instructions/description/suggested_queries/primers) and `ListSpaceSkills`/`GetSkillDetail` (collection-scoped skills + SKILL.md body). `ListSpaceSkills` omits `collection_uuid` when the UUID is empty (used to list account-wide global skills).
 - `internal/api/skills.go` — account-wide skills. `enrichSkill` (shared fail-soft helper: fetches detail + downloads SKILL.md body, used by both space and global paths), `ListGlobalSkills` (calls `ListSpaceSkills("")`, keeps only `scope=="global"`), and `GetAccount` (wraps global skills in `models.Account`). Global skills apply to every request account-wide, so they are exported **once** at the top level, not per space.
 - `internal/api/user.go` — `GetUser` via `GET /api/user`.
@@ -83,7 +83,7 @@ Answer content is in `entries[].blocks[]` where `intended_usage == "ask_text_0_m
 
 ## Export Flow
 
-1. **Phase 1 — Index**: `POST /rest/thread/list_ask_threads` with pagination (limit=20, ascending=false). Dual stop condition: `len(response) < limit` (primary) + all-duplicates (safety net). Result cached in `thread_index.json` with `Complete: true` flag.
+1. **Phase 1 — Index**: `POST /rest/thread/list_ask_threads` with pagination (limit=20, ascending=false). Dual stop condition: `len(response) < limit` (primary) + current-run all-duplicates (safety net). Result cached in `thread_index.json` with `Complete: true` flag. An incomplete index is never resumed from its count as an offset because the newest-first list can reorder between runs; the next run re-lists from offset 0 and carries retry metadata forward by UUID.
 2. **Phase 2 — Details**: `GET /rest/thread/{uuid}` for each thread. Skips threads already fetched on disk. Ordinary per-thread fetch/write failures preserve and render successful threads, but `manifest.json` records `threads_complete: false`, `expected_threads`, and ordered `failed_threads`, and the command exits non-zero after writing the manifest. Cancellation/deadline errors abort immediately and take precedence over accumulated failures. A failed `--refresh` must not count a stale cached thread as a current success. Adaptive rate limiting: delay doubles after 429, halves after 20 consecutive successes.
 3. **Phase 3 — Render**: Convert domain models to JSON/Markdown/PDF. Write threads to `threads/<slug>/` (canonical flat list). Copy thread files into `spaces/<name>/threads/<slug>/` so each space folder is self-contained. Account-wide global skills are written **once** under `account/`: `account/account.json` (JSON) + `account/global-skills.md` (Markdown), with each skill body in `account/skills/<name>.md`. They are not duplicated per space.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ deplexity export -f pdf --pdf-workers 4
 
 Export runs in two phases:
 
-1. **Phase 1 — Index**: Fetches the list of all threads and caches it in `thread_index.json`. If interrupted, re-running `deplexity export` resumes from the cached index.
+1. **Phase 1 — Index**: Fetches the list of all threads and caches it in `thread_index.json`. If listing is interrupted, the next run re-lists from the beginning and uses the incomplete cache only to preserve per-thread retry metadata. The upstream list is newest-first and can reorder, so a saved numeric offset is not a safe resume point.
 2. **Phase 2 — Details**: Fetches full content for each thread. Already-fetched threads are skipped automatically.
 
 Use `--refresh` to force re-fetching the thread index (e.g., after new conversations).

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -112,7 +112,10 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 	// === Phase 1: Thread index (list all UUIDs) ===
 	var threadRefs []models.ThreadRef
 	if cmd.Threads {
-		threadRefs, err = cmd.fetchThreadIndex(ctx, c, jsonExp)
+		listThreads := func(ctx context.Context, onProgress func(int)) ([]models.Thread, error) {
+			return api.ListThreads(ctx, c, onProgress)
+		}
+		threadRefs, err = cmd.fetchThreadIndex(ctx, jsonExp, listThreads)
 		if err != nil {
 			return err
 		}
@@ -281,8 +284,10 @@ func persistThreadRetryState(jsonExp *export.JSONExporter, refs []models.ThreadR
 	return nil
 }
 
-// fetchThreadIndex loads or fetches the thread UUID list (resumable).
-func (cmd *ExportCmd) fetchThreadIndex(ctx context.Context, c *client.Client, jsonExp *export.JSONExporter) ([]models.ThreadRef, error) {
+type listThreadsFunc func(context.Context, func(int)) ([]models.Thread, error)
+
+// fetchThreadIndex loads a complete cache or safely re-lists from the beginning.
+func (cmd *ExportCmd) fetchThreadIndex(ctx context.Context, jsonExp *export.JSONExporter, listThreads listThreadsFunc) ([]models.ThreadRef, error) {
 	// Check cache
 	if !cmd.Refresh {
 		index, err := jsonExp.LoadThreadIndex()
@@ -293,19 +298,16 @@ func (cmd *ExportCmd) fetchThreadIndex(ctx context.Context, c *client.Client, js
 			fmt.Printf("Using cached thread list (%d threads, fetched %s ago)\n", index.Total, time.Since(index.FetchedAt).Round(time.Minute))
 			return index.Threads, nil
 		}
-		// Resume from incomplete index
 		if index != nil && !index.Complete && index.Total > 0 {
-			fmt.Printf("Resuming thread list from %d...", index.Total)
-			return cmd.continueListThreads(ctx, c, jsonExp, index)
+			fmt.Printf("Cached thread list is incomplete (%d found); re-listing from the start because thread order may have changed\n", index.Total)
 		}
 	}
 
-	// Fresh fetch
-	return cmd.freshListThreads(ctx, c, jsonExp)
+	return cmd.freshListThreads(ctx, jsonExp, listThreads)
 }
 
-// freshListThreads fetches all threads from scratch, saving periodically.
-func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, jsonExp *export.JSONExporter) ([]models.ThreadRef, error) {
+// freshListThreads fetches all threads from scratch and saves partial progress.
+func (cmd *ExportCmd) freshListThreads(ctx context.Context, jsonExp *export.JSONExporter, listThreads listThreadsFunc) ([]models.ThreadRef, error) {
 	fmt.Print("Fetching thread list...")
 
 	index := &models.ThreadIndex{Complete: false}
@@ -315,7 +317,7 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 		previous = nil
 	}
 
-	threads, err := api.ListThreads(ctx, c, func(n int) {
+	threads, err := listThreads(ctx, func(n int) {
 		fmt.Printf("\rFetching thread list... %d", n)
 	})
 
@@ -324,12 +326,14 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 	if previous != nil {
 		attachPreviousUpdatedAt(refs, previous.Threads)
 	}
-	index.Threads = refs
-	index.Total = len(refs)
 	if err != nil {
+		index.Threads = mergeIncompleteThreadRefs(refs, previous)
+		index.Total = len(index.Threads)
 		_ = jsonExp.SaveThreadIndex(index)
 		return nil, err
 	}
+	index.Threads = refs
+	index.Total = len(refs)
 
 	fmt.Printf("\rFetching thread list... %d threads found\n", len(threads))
 
@@ -338,6 +342,29 @@ func (cmd *ExportCmd) freshListThreads(ctx context.Context, c *client.Client, js
 	}
 
 	return refs, nil
+}
+
+// mergeIncompleteThreadRefs keeps the current scan prefix first and retains
+// unseen prior refs only as metadata checkpoints. Incomplete indexes are never
+// served as complete data; the next run always re-lists from offset zero.
+func mergeIncompleteThreadRefs(refs []models.ThreadRef, previous *models.ThreadIndex) []models.ThreadRef {
+	if previous == nil {
+		return refs
+	}
+
+	merged := make([]models.ThreadRef, 0, len(refs)+len(previous.Threads))
+	merged = append(merged, refs...)
+	seen := make(map[string]bool, len(merged))
+	for _, ref := range merged {
+		seen[ref.UUID] = true
+	}
+	for _, ref := range previous.Threads {
+		if !seen[ref.UUID] {
+			merged = append(merged, ref)
+			seen[ref.UUID] = true
+		}
+	}
+	return merged
 }
 
 // indexServableFromCache reports whether a cached thread index can be reused
@@ -360,40 +387,6 @@ func finalizeIndex(jsonExp *export.JSONExporter, index *models.ThreadIndex) erro
 	index.FetchedAt = time.Now().UTC()
 	index.Complete = index.Total > 0
 	return jsonExp.SaveThreadIndex(index)
-}
-
-// continueListThreads resumes listing from a partial index.
-func (cmd *ExportCmd) continueListThreads(ctx context.Context, c *client.Client, jsonExp *export.JSONExporter, index *models.ThreadIndex) ([]models.ThreadRef, error) {
-	startOffset := index.Total
-
-	// Build seen set from existing threads to detect duplicates/recycling.
-	seenUUIDs := make(map[string]bool, len(index.Threads))
-	for _, ref := range index.Threads {
-		seenUUIDs[ref.UUID] = true
-	}
-
-	additional, err := api.ListThreadsFrom(ctx, c, startOffset, seenUUIDs, func(n int) {
-		fmt.Printf("\rResuming thread list... %d", n)
-	})
-
-	// Merge results
-	for _, t := range additional {
-		index.Threads = append(index.Threads, models.ThreadRef{UUID: t.UUID, Title: t.Title, SpaceUUID: t.SpaceUUID, UpdatedAt: t.UpdatedAt})
-	}
-	index.Total = len(index.Threads)
-
-	if err != nil {
-		_ = jsonExp.SaveThreadIndex(index)
-		return nil, err
-	}
-
-	fmt.Printf("\rFetching thread list... %d threads found\n", len(index.Threads))
-
-	if err := finalizeIndex(jsonExp, index); err != nil {
-		return nil, err
-	}
-
-	return index.Threads, nil
 }
 
 func buildRefsFromThreads(threads []models.Thread) []models.ThreadRef {

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -148,6 +149,174 @@ func TestFinalizeIndex(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchThreadIndexReListsIncompleteCacheFromStart(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	previousUpdatedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	previous := &models.ThreadIndex{
+		Threads: []models.ThreadRef{
+			{UUID: "old-1", UpdatedAt: previousUpdatedAt, RetryRequired: true},
+			{UUID: "stale"},
+		},
+		Total:    2,
+		Complete: false,
+	}
+	if err := jsonExp.SaveThreadIndex(previous); err != nil {
+		t.Fatalf("SaveThreadIndex: %v", err)
+	}
+
+	called := false
+	list := func(_ context.Context, onProgress func(int)) ([]models.Thread, error) {
+		called = true
+		if onProgress != nil {
+			onProgress(3)
+		}
+		return []models.Thread{
+			{UUID: "promoted", Title: "Promoted"},
+			{UUID: "old-1", Title: "Old"},
+			{UUID: "tail", Title: "Tail"},
+		}, nil
+	}
+
+	cmd := &ExportCmd{}
+	refs, err := cmd.fetchThreadIndex(context.Background(), jsonExp, list)
+	if err != nil {
+		t.Fatalf("fetchThreadIndex: %v", err)
+	}
+	if !called {
+		t.Fatal("incomplete cache was served without re-listing")
+	}
+	wantOrder := []string{"promoted", "old-1", "tail"}
+	if got := threadRefUUIDs(refs); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("refs = %v, want %v", got, wantOrder)
+	}
+	if !refs[1].RetryRequired || !refs[1].PreviousUpdatedAt.Equal(previousUpdatedAt) {
+		t.Fatalf("old-1 metadata = %#v, want retry and previous timestamp preserved", refs[1])
+	}
+
+	reloaded, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		t.Fatalf("LoadThreadIndex: %v", err)
+	}
+	if !reloaded.Complete || reloaded.Total != 3 {
+		t.Fatalf("persisted index = %#v, want complete total 3", reloaded)
+	}
+	if got := threadRefUUIDs(reloaded.Threads); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("persisted order = %v, want %v", got, wantOrder)
+	}
+}
+
+func TestFetchThreadIndexServesCompleteCacheWithoutListing(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	index := &models.ThreadIndex{
+		Threads:   []models.ThreadRef{{UUID: "cached"}},
+		Total:     1,
+		FetchedAt: time.Now().UTC(),
+		Complete:  true,
+	}
+	if err := jsonExp.SaveThreadIndex(index); err != nil {
+		t.Fatalf("SaveThreadIndex: %v", err)
+	}
+	list := func(context.Context, func(int)) ([]models.Thread, error) {
+		t.Fatal("list called for servable complete cache")
+		return nil, nil
+	}
+
+	cmd := &ExportCmd{}
+	refs, err := cmd.fetchThreadIndex(context.Background(), jsonExp, list)
+	if err != nil {
+		t.Fatalf("fetchThreadIndex: %v", err)
+	}
+	if got := threadRefUUIDs(refs); !reflect.DeepEqual(got, []string{"cached"}) {
+		t.Fatalf("refs = %v, want cached", got)
+	}
+}
+
+func TestFetchThreadIndexRefreshBypassesCompleteCacheAndDemotesOnError(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	index := &models.ThreadIndex{
+		Threads:   []models.ThreadRef{{UUID: "cached", RetryRequired: true}},
+		Total:     1,
+		FetchedAt: time.Now().UTC(),
+		Complete:  true,
+	}
+	if err := jsonExp.SaveThreadIndex(index); err != nil {
+		t.Fatalf("SaveThreadIndex: %v", err)
+	}
+	wantErr := errors.New("refresh interrupted")
+	called := false
+	list := func(context.Context, func(int)) ([]models.Thread, error) {
+		called = true
+		return []models.Thread{{UUID: "new-head"}}, wantErr
+	}
+
+	cmd := &ExportCmd{Refresh: true}
+	if _, err := cmd.fetchThreadIndex(context.Background(), jsonExp, list); !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want refresh interruption", err)
+	}
+	if !called {
+		t.Fatal("refresh served complete cache without listing")
+	}
+	reloaded, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		t.Fatalf("LoadThreadIndex: %v", err)
+	}
+	if reloaded.Complete {
+		t.Fatal("failed refresh left the previous index complete")
+	}
+	if got := threadRefUUIDs(reloaded.Threads); !reflect.DeepEqual(got, []string{"new-head", "cached"}) {
+		t.Fatalf("persisted refs = %v, want new prefix and prior cache", got)
+	}
+	if !reloaded.Threads[1].RetryRequired {
+		t.Fatal("prior retry metadata was lost during failed refresh")
+	}
+}
+
+func TestFetchThreadIndexInterruptedRelistRetainsPriorMetadata(t *testing.T) {
+	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
+	previous := &models.ThreadIndex{
+		Threads: []models.ThreadRef{
+			{UUID: "old-head"},
+			{UUID: "deep-retry", RetryRequired: true},
+		},
+		Total:    2,
+		Complete: false,
+	}
+	if err := jsonExp.SaveThreadIndex(previous); err != nil {
+		t.Fatalf("SaveThreadIndex: %v", err)
+	}
+	listErr := errors.New("listing interrupted")
+	list := func(context.Context, func(int)) ([]models.Thread, error) {
+		return []models.Thread{{UUID: "new-head"}, {UUID: "old-head"}}, listErr
+	}
+
+	cmd := &ExportCmd{}
+	if _, err := cmd.fetchThreadIndex(context.Background(), jsonExp, list); !errors.Is(err, listErr) {
+		t.Fatalf("error = %v, want listing interruption", err)
+	}
+	reloaded, err := jsonExp.LoadThreadIndex()
+	if err != nil {
+		t.Fatalf("LoadThreadIndex: %v", err)
+	}
+	if reloaded.Complete {
+		t.Fatal("interrupted re-list was marked complete")
+	}
+	wantOrder := []string{"new-head", "old-head", "deep-retry"}
+	if got := threadRefUUIDs(reloaded.Threads); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("persisted order = %v, want %v", got, wantOrder)
+	}
+	if !reloaded.Threads[2].RetryRequired {
+		t.Fatal("unseen prior retry metadata was lost")
+	}
+}
+
+func threadRefUUIDs(refs []models.ThreadRef) []string {
+	uuids := make([]string, len(refs))
+	for i := range refs {
+		uuids[i] = refs[i].UUID
+	}
+	return uuids
 }
 
 // TestExportFormatAccountGating locks in the render half of the --no-spaces

--- a/internal/api/threads.go
+++ b/internal/api/threads.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/clappingmonkey/deplexity/internal/client"
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
@@ -16,13 +15,19 @@ type getter interface {
 	Get(context.Context, string, any) error
 }
 
-// ListThreadsFrom fetches threads starting at a given offset via POST /rest/thread/list_ask_threads.
+type poster interface {
+	Post(context.Context, string, any, any) error
+}
+
+// ListThreads fetches all user threads via POST /rest/thread/list_ask_threads.
 // Stops when a page returns fewer than limit results (end of data) or when all results are
 // duplicates (safety net for API recycling behavior).
-func ListThreadsFrom(ctx context.Context, c *client.Client, startOffset int, seenUUIDs map[string]bool, onProgress func(int)) ([]models.Thread, error) {
+// If onProgress is non-nil, it is called after each page with the total count so far.
+func ListThreads(ctx context.Context, c poster, onProgress func(int)) ([]models.Thread, error) {
 	var allThreads []models.Thread
-	offset := startOffset
+	offset := 0
 	limit := 20
+	seenUUIDs := make(map[string]bool)
 
 	path := fmt.Sprintf("/rest/thread/list_ask_threads?version=%s&source=default", apiVersion)
 
@@ -74,7 +79,7 @@ func ListThreadsFrom(ctx context.Context, c *client.Client, startOffset int, see
 		}
 
 		if onProgress != nil {
-			onProgress(startOffset + len(allThreads))
+			onProgress(len(allThreads))
 		}
 
 		// If no new threads were found, the API is recycling — stop.
@@ -91,12 +96,6 @@ func ListThreadsFrom(ctx context.Context, c *client.Client, startOffset int, see
 	}
 
 	return allThreads, nil
-}
-
-// ListThreads fetches all user threads via POST /rest/thread/list_ask_threads.
-// If onProgress is non-nil, it is called after each page with the total count so far.
-func ListThreads(ctx context.Context, c *client.Client, onProgress func(int)) ([]models.Thread, error) {
-	return ListThreadsFrom(ctx, c, 0, make(map[string]bool), onProgress)
 }
 
 // threadPagePath builds the detail endpoint URL for a single page of a thread.

--- a/internal/api/threads_test.go
+++ b/internal/api/threads_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +16,28 @@ type threadGetter struct {
 	responses []ThreadDetailResponse
 	calls     int
 	paths     []string
+}
+
+type threadPoster struct {
+	responses []ThreadListResponse
+	errors    []error
+	calls     int
+	offsets   []int
+}
+
+func (p *threadPoster) Post(_ context.Context, _ string, body any, dst any) error {
+	req := body.(ThreadListRequest)
+	p.offsets = append(p.offsets, req.Offset)
+	if p.calls >= len(p.responses) {
+		return errors.New("unexpected list request")
+	}
+	call := p.calls
+	p.calls++
+	if call < len(p.errors) && p.errors[call] != nil {
+		return p.errors[call]
+	}
+	*dst.(*ThreadListResponse) = p.responses[call]
+	return nil
 }
 
 func (g *threadGetter) Get(_ context.Context, path string, dst any) error {
@@ -87,6 +111,74 @@ func TestThreadListItemMapping(t *testing.T) {
 	}
 	if raw.Title != "Test Thread" {
 		t.Errorf("unexpected Title: %s", raw.Title)
+	}
+}
+
+func TestListThreadsStartsAtZeroAndAdvancesByPageLength(t *testing.T) {
+	first := make(ThreadListResponse, 20)
+	for i := range first {
+		first[i] = ThreadListItem{UUID: fmt.Sprintf("thread-%d", i)}
+	}
+	poster := &threadPoster{responses: []ThreadListResponse{
+		first,
+		{{UUID: "thread-20"}},
+	}}
+	var progress []int
+
+	threads, err := ListThreads(context.Background(), poster, func(n int) {
+		progress = append(progress, n)
+	})
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 21 {
+		t.Fatalf("got %d threads, want 21", len(threads))
+	}
+	if !reflect.DeepEqual(poster.offsets, []int{0, 20}) {
+		t.Errorf("offsets = %v, want [0 20]", poster.offsets)
+	}
+	if !reflect.DeepEqual(progress, []int{20, 21}) {
+		t.Errorf("progress = %v, want [20 21]", progress)
+	}
+}
+
+func TestListThreadsStopsOnCurrentRunDuplicatePage(t *testing.T) {
+	first := make(ThreadListResponse, 20)
+	for i := range first {
+		first[i] = ThreadListItem{UUID: fmt.Sprintf("thread-%d", i)}
+	}
+	duplicate := append(ThreadListResponse(nil), first...)
+	poster := &threadPoster{responses: []ThreadListResponse{first, duplicate}}
+
+	threads, err := ListThreads(context.Background(), poster, nil)
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 20 {
+		t.Fatalf("got %d threads, want 20 unique threads", len(threads))
+	}
+	if poster.calls != 2 {
+		t.Fatalf("calls = %d, want 2", poster.calls)
+	}
+}
+
+func TestListThreadsReturnsPartialResultsOnPageError(t *testing.T) {
+	first := make(ThreadListResponse, 20)
+	for i := range first {
+		first[i] = ThreadListItem{UUID: fmt.Sprintf("thread-%d", i)}
+	}
+	wantErr := errors.New("second page failed")
+	poster := &threadPoster{
+		responses: []ThreadListResponse{first, nil},
+		errors:    []error{nil, wantErr},
+	}
+
+	threads, err := ListThreads(context.Background(), poster, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want second page failure", err)
+	}
+	if len(threads) != 20 {
+		t.Fatalf("got %d partial threads, want 20", len(threads))
 	}
 }
 


### PR DESCRIPTION
## Description

Restart incomplete thread-index listings from offset zero instead of treating the cached item count as a stable pagination cursor.

Perplexity returns threads newest-first, so new or newly active conversations can reorder the list between runs. A saved numeric offset could therefore skip unseen threads and allow a truncated index to be marked complete. Successful scans now replace the index in current API order, while interrupted scans remain incomplete and retain prior retry metadata by UUID.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go vet ./...`, `go test -race ./...`, `bazel build //cmd/deplexity`, and `bazel run //:gazelle` pass;

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Interrupted thread-index listings now restart safely from the beginning, preventing newest-first list reordering from silently skipping conversations.
