### PR TITLE
fix: make request pacing cancellable

### DIFF
--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -83,6 +83,10 @@ type ExportCmd struct {
 
 func (cmd *ExportCmd) Run(ctx context.Context) error {
 	startTime := time.Now()
+	delay, err := requestDelay(cmd.Delay)
+	if err != nil {
+		return err
+	}
 
 	session, err := auth.LoadSession()
 	if err != nil {
@@ -93,7 +97,7 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.SetDelay(time.Duration(cmd.Delay) * time.Millisecond)
+	c.SetDelay(delay)
 	c.SetVerbose(cmd.verbose)
 
 	jsonExp := &export.JSONExporter{OutputDir: cmd.Output}
@@ -222,6 +226,17 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 
 	fmt.Printf("\nExport complete: %s (%s)\n", cmd.Output, time.Since(startTime).Round(time.Second))
 	return nil
+}
+
+func requestDelay(milliseconds int) (time.Duration, error) {
+	if milliseconds < 0 {
+		return 0, errors.New("--delay must be non-negative")
+	}
+	maxMilliseconds := int64((time.Duration(1<<63 - 1)) / time.Millisecond)
+	if int64(milliseconds) > maxMilliseconds {
+		return 0, errors.New("--delay is too large")
+	}
+	return time.Duration(milliseconds) * time.Millisecond, nil
 }
 
 func finalizeExport(jsonExp *export.JSONExporter, manifest *models.ExportManifest) error {

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -47,6 +47,54 @@ func TestNeedsThreadFetch(t *testing.T) {
 	}
 }
 
+func TestRequestDelayValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   int
+		want time.Duration
+		err  string
+	}{
+		{name: "zero", ms: 0},
+		{name: "positive", ms: 500, want: 500 * time.Millisecond},
+		{name: "negative", ms: -1, err: "--delay must be non-negative"},
+	}
+	maxInt := int(^uint(0) >> 1)
+	maxMilliseconds := int64((time.Duration(1<<63 - 1)) / time.Millisecond)
+	if int64(maxInt) > maxMilliseconds {
+		tests = append(tests, struct {
+			name string
+			ms   int
+			want time.Duration
+			err  string
+		}{name: "overflow", ms: int(maxMilliseconds + 1), err: "--delay is too large"})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := requestDelay(tt.ms)
+			if tt.err != "" {
+				if err == nil || err.Error() != tt.err {
+					t.Fatalf("requestDelay(%d) error = %v, want %q", tt.ms, err, tt.err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("requestDelay(%d): %v", tt.ms, err)
+			}
+			if got != tt.want {
+				t.Errorf("requestDelay(%d) = %v, want %v", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExportRejectsNegativeDelayBeforeSessionLoad(t *testing.T) {
+	cmd := &ExportCmd{Delay: -1}
+	if err := cmd.Run(context.Background()); err == nil || err.Error() != "--delay must be non-negative" {
+		t.Fatalf("Run error = %v, want negative delay validation", err)
+	}
+}
+
 func TestResumePoint(t *testing.T) {
 	partial := &models.Thread{NextCursor: "c1"}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -47,13 +47,14 @@ var ErrNotAuthenticated = errors.New("authentication failed — run 'deplexity l
 
 // Client is an authenticated HTTP client for the Perplexity internal API.
 type Client struct {
-	http    *http.Client
-	baseURL string
-	delay            time.Duration
-	lastReq          time.Time
-	consecutiveOK    int // consecutive 200s since last 429
-	cookies          []*http.Cookie
-	verbose          bool
+	http          *http.Client
+	baseURL       string
+	delay         time.Duration
+	lastReq       time.Time
+	waitDelay     func(context.Context, time.Duration) error
+	consecutiveOK int // consecutive 200s since last 429
+	cookies       []*http.Cookie
+	verbose       bool
 }
 
 // New creates a new authenticated client from a saved session.
@@ -107,7 +108,9 @@ func (c *Client) Get(ctx context.Context, path string, dest interface{}) error {
 			return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
 		}
 
-		c.rateLimit()
+		if err := c.rateLimit(ctx); err != nil {
+			return err
+		}
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 		if err != nil {
@@ -203,7 +206,9 @@ func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
 			return nil, fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
 		}
 
-		c.rateLimit()
+		if err := c.rateLimit(ctx); err != nil {
+			return nil, err
+		}
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 		if err != nil {
@@ -329,7 +334,9 @@ func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
 		// inside the pre-signed URL's ~15 min validity window. onSuccess/
 		// onRateLimited are intentionally NOT called: S3 rate limits are
 		// independent of Perplexity's and must not perturb its adaptive delay.
-		c.rateLimit()
+		if err := c.rateLimit(ctx); err != nil {
+			return nil, err
+		}
 
 		req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
 		if err != nil {
@@ -415,7 +422,9 @@ func (c *Client) Post(ctx context.Context, path string, body interface{}, dest i
 			return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
 		}
 
-		c.rateLimit()
+		if err := c.rateLimit(ctx); err != nil {
+			return err
+		}
 
 		var bodyReader io.Reader
 		if body != nil {
@@ -532,15 +541,40 @@ func (c *Client) setHeaders(req *http.Request) {
 	}
 }
 
-// rateLimit enforces the configured delay between requests.
-func (c *Client) rateLimit() {
+// rateLimit enforces the configured delay between requests without delaying
+// cancellation. lastReq advances only when the caller may issue a request.
+func (c *Client) rateLimit(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if c.delay > 0 && !c.lastReq.IsZero() {
 		elapsed := time.Since(c.lastReq)
 		if elapsed < c.delay {
-			time.Sleep(c.delay - elapsed)
+			wait := c.waitDelay
+			if wait == nil {
+				wait = waitForDelay
+			}
+			if err := wait(ctx, c.delay-elapsed); err != nil {
+				return err
+			}
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	c.lastReq = time.Now()
+	return nil
+}
+
+func waitForDelay(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // onSuccess records a successful request and gradually lowers the

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,9 +3,12 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
@@ -82,6 +85,149 @@ func TestClientGetContextCancellation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
+}
+
+func TestRateLimitCancellationPreservesLastRequest(t *testing.T) {
+	lastReq := time.Now()
+	entered := make(chan struct{})
+	c := &Client{
+		delay:   time.Hour,
+		lastReq: lastReq,
+		waitDelay: func(ctx context.Context, _ time.Duration) error {
+			close(entered)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- c.rateLimit(ctx)
+	}()
+
+	<-entered
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("rateLimit error = %v, want context.Canceled", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("rateLimit did not return promptly after cancellation")
+	}
+	if !c.lastReq.Equal(lastReq) {
+		t.Errorf("lastReq = %v, want unchanged %v", c.lastReq, lastReq)
+	}
+}
+
+func TestRateLimitWaitCompletionRecordsRequestTimestamp(t *testing.T) {
+	previous := time.Now()
+	waited := false
+	c := &Client{
+		delay:   time.Hour,
+		lastReq: previous,
+		waitDelay: func(context.Context, time.Duration) error {
+			waited = true
+			return nil
+		},
+	}
+	if err := c.rateLimit(context.Background()); err != nil {
+		t.Fatalf("rateLimit: %v", err)
+	}
+	if !waited {
+		t.Fatal("rateLimit did not enter the wait path")
+	}
+	if !c.lastReq.After(previous) {
+		t.Errorf("lastReq = %v, want after %v", c.lastReq, previous)
+	}
+}
+
+func TestRateLimitRejectsPreCancelledContextWithoutTimestamp(t *testing.T) {
+	c := &Client{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := c.rateLimit(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("rateLimit error = %v, want context.Canceled", err)
+	}
+	if !c.lastReq.IsZero() {
+		t.Errorf("lastReq = %v, want zero", c.lastReq)
+	}
+}
+
+func TestRateLimitSuccessRecordsRequestTimestamp(t *testing.T) {
+	c := &Client{}
+	before := time.Now()
+	if err := c.rateLimit(context.Background()); err != nil {
+		t.Fatalf("rateLimit: %v", err)
+	}
+	if c.lastReq.Before(before) {
+		t.Errorf("lastReq = %v, want at or after %v", c.lastReq, before)
+	}
+}
+
+func TestClientMethodsCancellationDuringPacingSkipsRequest(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{name: "Get", call: func(ctx context.Context, c *Client) error { return c.Get(ctx, "/test", nil) }},
+		{name: "GetRaw", call: func(ctx context.Context, c *Client) error { _, err := c.GetRaw(ctx, "/test"); return err }},
+		{name: "GetRawURL", call: func(ctx context.Context, c *Client) error { _, err := c.GetRawURL(ctx, srv.URL+"/test"); return err }},
+		{name: "Post", call: func(ctx context.Context, c *Client) error { return c.Post(ctx, "/test", nil, nil) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reached atomic.Bool
+			entered := make(chan struct{})
+			clientHTTP := srv.Client()
+			clientHTTP.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				reached.Store(true)
+				return srv.Client().Transport.RoundTrip(req)
+			})
+			c := &Client{
+				http:    clientHTTP,
+				baseURL: srv.URL,
+				delay:   time.Hour,
+				lastReq: time.Now(),
+				waitDelay: func(ctx context.Context, _ time.Duration) error {
+					close(entered)
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			result := make(chan error, 1)
+			go func() { result <- tt.call(ctx, c) }()
+			<-entered
+			cancel()
+
+			select {
+			case err := <-result:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("error = %v, want context.Canceled", err)
+				}
+			case <-time.After(500 * time.Millisecond):
+				t.Fatal("request did not return promptly after pacing cancellation")
+			}
+			if reached.Load() {
+				t.Fatal("HTTP transport was reached after pacing cancellation")
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestGetRawURLIsolatesHeaders(t *testing.T) {


### PR DESCRIPTION
## Description

Allow context cancellation and deadlines to interrupt the configured delay between API requests instead of waiting for the pacing interval to finish.

All authenticated and third-party request methods now stop before reaching the HTTP transport when pacing is cancelled, and cancelled waits do not advance the client's last-request timestamp. The export command also rejects negative or overflowing `--delay` values before loading session data while continuing to allow zero to disable pacing.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: Ran `bazel run //:gazelle`, `go vet ./...`, `go test -race ./...`, `bazel build //cmd/deplexity`, targeted client/CLI tests, and `git diff --check`. Deterministic tests synchronize on the pacing wait boundary, cover successful and cancelled waits, verify `lastReq` semantics, prove `Get`, `GetRaw`, `GetRawURL`, and `Post` do not reach transport after cancellation, and validate negative/zero/overflow delay handling.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Cancelling an export now interrupts API request pacing immediately, including when a long custom `--delay` is configured.