### PR TITLE
fix: avoid final retry backoff

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	delay         time.Duration
 	lastReq       time.Time
 	waitDelay     func(context.Context, time.Duration) error
+	retryWait     func(context.Context, time.Duration) error
 	consecutiveOK int // consecutive 200s since last 429
 	cookies       []*http.Cookie
 	verbose       bool
@@ -101,13 +102,6 @@ func (c *Client) Get(ctx context.Context, path string, dest interface{}) error {
 	netAttempt := 0
 
 	for {
-		if httpAttempt > maxRetries {
-			return fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
-		}
-		if netAttempt > maxNetworkRetries {
-			return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
-		}
-
 		if err := c.rateLimit(ctx); err != nil {
 			return err
 		}
@@ -126,16 +120,20 @@ func (c *Client) Get(ctx context.Context, path string, dest interface{}) error {
 				return ctx.Err()
 			}
 			netAttempt++
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if netAttempt > maxNetworkRetries {
+				return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
+			}
 			backoff := computeBackoff(netAttempt-1, networkRetryBase, networkRetryMax)
 			if c.verbose {
 				log.Printf("[DEBUG] network error, backing off %s (attempt %d/%d): %v", backoff, netAttempt, maxNetworkRetries, err)
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return err
 			}
+			continue
 		}
 
 		// Reset network attempt counter on any successful connection.
@@ -154,16 +152,20 @@ func (c *Client) Get(ctx context.Context, path string, dest interface{}) error {
 				c.onRateLimited()
 			}
 			httpAttempt++
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if httpAttempt > maxRetries {
+				return fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
+			}
 			backoff := computeBackoff(httpAttempt-1, baseBackoff, maxBackoff)
 			if c.verbose {
 				log.Printf("[DEBUG] retryable error %d, backing off %s (attempt %d/%d)", resp.StatusCode, backoff, httpAttempt, maxRetries)
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return err
 			}
+			continue
 		}
 
 		defer resp.Body.Close()
@@ -199,13 +201,6 @@ func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
 	netAttempt := 0
 
 	for {
-		if httpAttempt > maxRetries {
-			return nil, fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
-		}
-		if netAttempt > maxNetworkRetries {
-			return nil, fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
-		}
-
 		if err := c.rateLimit(ctx); err != nil {
 			return nil, err
 		}
@@ -223,16 +218,20 @@ func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
 				return nil, ctx.Err()
 			}
 			netAttempt++
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if netAttempt > maxNetworkRetries {
+				return nil, fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
+			}
 			backoff := computeBackoff(netAttempt-1, networkRetryBase, networkRetryMax)
 			if c.verbose {
 				log.Printf("[DEBUG] network error, backing off %s (attempt %d/%d): %v", backoff, netAttempt, maxNetworkRetries, err)
 			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return nil, err
 			}
+			continue
 		}
 
 		netAttempt = 0
@@ -250,16 +249,20 @@ func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
 				c.onRateLimited()
 			}
 			httpAttempt++
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if httpAttempt > maxRetries {
+				return nil, fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
+			}
 			backoff := computeBackoff(httpAttempt-1, baseBackoff, maxBackoff)
 			if c.verbose {
 				log.Printf("[DEBUG] retryable error %d, backing off %s (attempt %d/%d)", resp.StatusCode, backoff, httpAttempt, maxRetries)
 			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return nil, err
 			}
+			continue
 		}
 
 		defer resp.Body.Close()
@@ -321,13 +324,6 @@ func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
 	netAttempt := 0
 
 	for {
-		if httpAttempt > maxRetries {
-			return nil, fmt.Errorf("request to %s failed after %d retries", rawURL, maxRetries)
-		}
-		if netAttempt > maxNetworkRetries {
-			return nil, fmt.Errorf("request to %s failed after %d network retries", rawURL, maxNetworkRetries)
-		}
-
 		// Reuse the shared inter-request pacing so a single client stays polite
 		// across mixed Perplexity/S3 traffic. The adaptive delay is capped
 		// (maxDelay) and skill bodies are fetched eagerly, so this stays well
@@ -352,16 +348,20 @@ func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
 				return nil, ctx.Err()
 			}
 			netAttempt++
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if netAttempt > maxNetworkRetries {
+				return nil, fmt.Errorf("request to %s failed after %d network retries", rawURL, maxNetworkRetries)
+			}
 			backoff := computeBackoff(netAttempt-1, networkRetryBase, networkRetryMax)
 			if c.verbose {
 				log.Printf("[DEBUG] network error, backing off %s (attempt %d/%d): %v", backoff, netAttempt, maxNetworkRetries, err)
 			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return nil, err
 			}
+			continue
 		}
 
 		netAttempt = 0
@@ -376,16 +376,20 @@ func (c *Client) GetRawURL(ctx context.Context, rawURL string) ([]byte, error) {
 			resp.StatusCode == http.StatusGatewayTimeout {
 			resp.Body.Close()
 			httpAttempt++
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if httpAttempt > maxRetries {
+				return nil, fmt.Errorf("request to %s failed after %d retries", rawURL, maxRetries)
+			}
 			backoff := computeBackoff(httpAttempt-1, baseBackoff, maxBackoff)
 			if c.verbose {
 				log.Printf("[DEBUG] retryable error %d, backing off %s (attempt %d/%d)", resp.StatusCode, backoff, httpAttempt, maxRetries)
 			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return nil, err
 			}
+			continue
 		}
 
 		// Read one byte past the cap so an oversized body is detected as an
@@ -415,13 +419,6 @@ func (c *Client) Post(ctx context.Context, path string, body interface{}, dest i
 	netAttempt := 0
 
 	for {
-		if httpAttempt > maxRetries {
-			return fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
-		}
-		if netAttempt > maxNetworkRetries {
-			return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
-		}
-
 		if err := c.rateLimit(ctx); err != nil {
 			return err
 		}
@@ -451,16 +448,20 @@ func (c *Client) Post(ctx context.Context, path string, body interface{}, dest i
 				return ctx.Err()
 			}
 			netAttempt++
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if netAttempt > maxNetworkRetries {
+				return fmt.Errorf("request to %s failed after %d network retries", path, maxNetworkRetries)
+			}
 			backoff := computeBackoff(netAttempt-1, networkRetryBase, networkRetryMax)
 			if c.verbose {
 				log.Printf("[DEBUG] network error, backing off %s (attempt %d/%d): %v", backoff, netAttempt, maxNetworkRetries, err)
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return err
 			}
+			continue
 		}
 
 		netAttempt = 0
@@ -478,16 +479,20 @@ func (c *Client) Post(ctx context.Context, path string, body interface{}, dest i
 				c.onRateLimited()
 			}
 			httpAttempt++
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if httpAttempt > maxRetries {
+				return fmt.Errorf("request to %s failed after %d retries", path, maxRetries)
+			}
 			backoff := computeBackoff(httpAttempt-1, baseBackoff, maxBackoff)
 			if c.verbose {
 				log.Printf("[DEBUG] retryable error %d, backing off %s (attempt %d/%d)", resp.StatusCode, backoff, httpAttempt, maxRetries)
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
-				continue
+			if err := c.waitForRetry(ctx, backoff); err != nil {
+				return err
 			}
+			continue
 		}
 
 		defer resp.Body.Close()
@@ -575,6 +580,13 @@ func waitForDelay(ctx context.Context, delay time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+func (c *Client) waitForRetry(ctx context.Context, delay time.Duration) error {
+	if c.retryWait != nil {
+		return c.retryWait(ctx, delay)
+	}
+	return waitForDelay(ctx, delay)
 }
 
 // onSuccess records a successful request and gradually lowers the

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -228,6 +230,262 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func TestClientMethodsDoNotWaitAfterFinalHTTPRetry(t *testing.T) {
+	for _, method := range retryMethodCases() {
+		t.Run(method.name, func(t *testing.T) {
+			calls := 0
+			waits := 0
+			closed := 0
+			c := &Client{
+				http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       &trackingReadCloser{Reader: strings.NewReader("unavailable"), closed: &closed},
+						Header:     make(http.Header),
+					}, nil
+				})},
+				baseURL: "https://example.test",
+				retryWait: func(context.Context, time.Duration) error {
+					waits++
+					return nil
+				},
+			}
+
+			err := method.call(context.Background(), c)
+			if err == nil || !strings.Contains(err.Error(), "failed after 5 retries") {
+				t.Fatalf("error = %v, want HTTP retry exhaustion", err)
+			}
+			if calls != maxRetries+1 || waits != maxRetries {
+				t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxRetries+1, maxRetries)
+			}
+			if closed != calls {
+				t.Errorf("closed bodies=%d, want %d", closed, calls)
+			}
+		})
+	}
+}
+
+func TestClientMethodsSucceedOnFinalHTTPAttempt(t *testing.T) {
+	for _, method := range retryMethodCases() {
+		t.Run(method.name, func(t *testing.T) {
+			calls := 0
+			waits := 0
+			c := &Client{
+				http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					status := http.StatusServiceUnavailable
+					if calls == maxRetries+1 {
+						status = http.StatusOK
+					}
+					return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+				})},
+				baseURL: "https://example.test",
+				retryWait: func(context.Context, time.Duration) error {
+					waits++
+					return nil
+				},
+			}
+
+			if err := method.call(context.Background(), c); err != nil {
+				t.Fatalf("final allowed attempt failed: %v", err)
+			}
+			if calls != maxRetries+1 || waits != maxRetries {
+				t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxRetries+1, maxRetries)
+			}
+		})
+	}
+}
+
+func TestClientMethodsDoNotWaitAfterFinalNetworkRetry(t *testing.T) {
+	wantErr := errors.New("network unavailable")
+	for _, method := range retryMethodCases() {
+		t.Run(method.name, func(t *testing.T) {
+			calls := 0
+			waits := 0
+			c := &Client{
+				http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					return nil, wantErr
+				})},
+				baseURL: "https://example.test",
+				retryWait: func(context.Context, time.Duration) error {
+					waits++
+					return nil
+				},
+			}
+
+			err := method.call(context.Background(), c)
+			if err == nil || !strings.Contains(err.Error(), "failed after 15 network retries") {
+				t.Fatalf("error = %v, want network retry exhaustion", err)
+			}
+			if calls != maxNetworkRetries+1 || waits != maxNetworkRetries {
+				t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxNetworkRetries+1, maxNetworkRetries)
+			}
+		})
+	}
+}
+
+func TestClientMethodsSucceedOnFinalNetworkAttempt(t *testing.T) {
+	wantErr := errors.New("network unavailable")
+	for _, method := range retryMethodCases() {
+		t.Run(method.name, func(t *testing.T) {
+			calls := 0
+			waits := 0
+			c := &Client{
+				http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					if calls <= maxNetworkRetries {
+						return nil, wantErr
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+				})},
+				baseURL: "https://example.test",
+				retryWait: func(context.Context, time.Duration) error {
+					waits++
+					return nil
+				},
+			}
+
+			if err := method.call(context.Background(), c); err != nil {
+				t.Fatalf("final allowed attempt failed: %v", err)
+			}
+			if calls != maxNetworkRetries+1 || waits != maxNetworkRetries {
+				t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxNetworkRetries+1, maxNetworkRetries)
+			}
+		})
+	}
+}
+
+func TestRetryWaitCancellationStopsBeforeNextRequest(t *testing.T) {
+	for _, method := range retryMethodCases() {
+		t.Run(method.name, func(t *testing.T) {
+			calls := 0
+			entered := make(chan struct{})
+			c := &Client{
+				http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+				})},
+				baseURL: "https://example.test",
+				retryWait: func(ctx context.Context, _ time.Duration) error {
+					close(entered)
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			result := make(chan error, 1)
+			go func() { result <- method.call(ctx, c) }()
+			<-entered
+			cancel()
+
+			select {
+			case err := <-result:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("error = %v, want context.Canceled", err)
+				}
+			case <-time.After(500 * time.Millisecond):
+				t.Fatal("request did not return promptly after retry cancellation")
+			}
+			if calls != 1 {
+				t.Errorf("calls = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestFinalRateLimitResponseUpdatesAdaptiveDelayWithoutWaiting(t *testing.T) {
+	calls := 0
+	waits := 0
+	c := &Client{
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		})},
+		baseURL: "https://example.test",
+		delay:   DefaultDelay / 4,
+		waitDelay: func(context.Context, time.Duration) error {
+			return nil
+		},
+		retryWait: func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		},
+	}
+
+	err := c.Get(context.Background(), "/test", nil)
+	if err == nil || !strings.Contains(err.Error(), "failed after 5 retries") {
+		t.Fatalf("error = %v, want HTTP retry exhaustion", err)
+	}
+	if calls != maxRetries+1 || waits != maxRetries {
+		t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxRetries+1, maxRetries)
+	}
+	if c.delay != maxDelay {
+		t.Errorf("adaptive delay = %v, want capped %v", c.delay, maxDelay)
+	}
+}
+
+func TestRawURLRateLimitDoesNotChangeAdaptiveDelay(t *testing.T) {
+	calls := 0
+	waits := 0
+	c := &Client{
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		})},
+		baseURL: "https://example.test",
+		delay:   DefaultDelay,
+		waitDelay: func(context.Context, time.Duration) error {
+			return nil
+		},
+		retryWait: func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		},
+	}
+
+	_, err := c.GetRawURL(context.Background(), "https://example.test/test")
+	if err == nil || !strings.Contains(err.Error(), "failed after 5 retries") {
+		t.Fatalf("error = %v, want HTTP retry exhaustion", err)
+	}
+	if calls != maxRetries+1 || waits != maxRetries {
+		t.Errorf("calls=%d waits=%d, want %d calls and %d waits", calls, waits, maxRetries+1, maxRetries)
+	}
+	if c.delay != DefaultDelay {
+		t.Errorf("adaptive delay = %v, want unchanged %v", c.delay, DefaultDelay)
+	}
+}
+
+type retryMethodCase struct {
+	name string
+	call func(context.Context, *Client) error
+}
+
+func retryMethodCases() []retryMethodCase {
+	return []retryMethodCase{
+		{name: "Get", call: func(ctx context.Context, c *Client) error { return c.Get(ctx, "/test", nil) }},
+		{name: "GetRaw", call: func(ctx context.Context, c *Client) error { _, err := c.GetRaw(ctx, "/test"); return err }},
+		{name: "GetRawURL", call: func(ctx context.Context, c *Client) error {
+			_, err := c.GetRawURL(ctx, "https://example.test/test")
+			return err
+		}},
+		{name: "Post", call: func(ctx context.Context, c *Client) error {
+			return c.Post(ctx, "/test", map[string]string{"key": "value"}, nil)
+		}},
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed *int
+}
+
+func (r *trackingReadCloser) Close() error {
+	*r.closed++
+	return nil
 }
 
 func TestGetRawURLIsolatesHeaders(t *testing.T) {


### PR DESCRIPTION
## Description

Stop HTTP client methods from sleeping after the final exhausted HTTP or
network retry. Retry budgets remain unchanged, while cancellation precedence,
response cleanup, and adaptive rate-limit updates are preserved.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go test -race ./...`, `go vet ./...`,
  `bazel build //cmd/deplexity`, `bazel run //:gazelle`, and
  `git diff --check`

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

HTTP requests now return immediately when their retry budget is exhausted
instead of waiting through a final backoff when no further attempt will occur.

## Additional Context

No dependent PRs. Both independent code review and adversarial validation
approved the change.
