### PR TITLE
fix: make PDF rendering interruptible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Binary entrypoint: `cmd/deplexity/main.go`. Version/buildTime stamped via `x_def
 
 **For `login` only:** Chrome or Chromium is needed for browser-based authentication. If not found, Rod automatically downloads Chromium (~80MB, one-time, cached at `~/.cache/rod/`).
 
-**For `export --cookie` and PDF:** No browser required at any point. `login --cookie <TOKEN>` bypasses the browser entirely. PDF export uses `gpdf` (pure Go, no CGO, no browser subprocess).
+**For `export --cookie` and PDF:** No browser required at any point. `login --cookie <TOKEN>` bypasses the browser entirely. PDF export uses `gpdf` (pure Go, no CGO) in isolated helper subprocesses of the Deplexity binary so cancellation and per-thread timeouts can terminate a stuck renderer.
 
 ## Perplexity API Details
 
@@ -101,7 +101,7 @@ Use `--refresh` to force re-fetching the thread index.
 - Thread directories must be derived with `threadDirName`, not by sanitizing the slug directly; the UUID-derived identity suffix prevents normalized slug collisions across every exporter and space copy.
 - Signal handling: first Ctrl+C cancels the context (graceful stop after current operation), second Ctrl+C force-exits via default OS handler. Implemented via `signal.NotifyContext` + dedicated `signal.Notify` channel (avoids spurious message on normal exit).
 - PDF sources rendered as numbered list `"N. Title (domain)"` — avoids gpdf hang on long unbreakable URLs (S3 pre-signed URLs up to 1600 chars). Previous table layout caused infinite loops in gpdf's word-wrap.
-- Multi-threaded PDF export: `--pdf-workers` flag (default: `runtime.NumCPU()`). Each worker creates its own `gpdf.Document` so no locking needed.
+- Multi-threaded PDF export: `--pdf-workers` flag (default: `runtime.NumCPU()`). Each worker launches an isolated Deplexity helper subprocess that creates its own `gpdf.Document`. `--pdf-timeout` defaults to 30 minutes per thread (`0` disables); timeout errors identify the thread, terminate its helper, leave any existing canonical PDF unchanged, cancel remaining PDF work, and exit non-zero. Space PDFs copy the successfully rendered canonical thread PDF instead of invoking gpdf again.
 
 ## Bazel
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ deplexity export --delay 1000
 
 # Control PDF parallelism (default: auto-detect CPU count)
 deplexity export -f pdf --pdf-workers 4
+
+# Change the per-PDF render timeout (default: 30m; 0 disables)
+deplexity export -f pdf --pdf-timeout 1h
 ```
+
+Each PDF is rendered in an isolated helper process. Ctrl+C terminates active PDF
+renderers, and a renderer that exceeds `--pdf-timeout` is killed so one
+pathological document cannot block an unattended export forever. A timeout names
+the affected thread explicitly, leaves any existing PDF unchanged, cancels the
+remaining PDF work, and exits non-zero.
 
 ### Resumable Exports
 

--- a/cmd/deplexity/BUILD.bazel
+++ b/cmd/deplexity/BUILD.bazel
@@ -33,5 +33,6 @@ go_test(
     deps = [
         "//internal/export",
         "//internal/models",
+        "@com_github_alecthomas_kong//:kong",
     ],
 )

--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -2,12 +2,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,6 +35,21 @@ var (
 )
 
 var errIncompleteThreadExport = errors.New("thread export incomplete")
+
+const (
+	pdfHelperArg      = "__pdf-render-helper"
+	maxPDFRequestSize = 100 * 1024 * 1024
+	maxPDFErrorSize   = 64 * 1024
+)
+
+var pdfCommand = func(ctx context.Context) (*exec.Cmd, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, executable, pdfHelperArg)
+	return cmd, nil
+}
 
 // CLI defines the top-level command structure.
 type CLI struct {
@@ -69,14 +90,15 @@ func (cmd *LoginCmd) Run(ctx context.Context) error {
 
 // ExportCmd handles data export.
 type ExportCmd struct {
-	Output     string   `short:"o" default:"deplexity-export" help:"Output directory."`
-	Format     []string `short:"f" default:"json,markdown" help:"Export formats (json, markdown, pdf)." enum:"json,markdown,pdf"`
-	Threads    bool     `help:"Export threads." default:"true" negatable:""`
-	Spaces     bool     `help:"Export spaces/collections." default:"true" negatable:""`
-	Profile    bool     `help:"Export user profile." default:"true" negatable:""`
-	Delay      int      `help:"Delay between API requests in milliseconds." default:"500"`
-	Refresh    bool     `help:"Re-fetch the thread list and updated thread details." default:"false"`
-	PDFWorkers int      `help:"Number of parallel workers for PDF generation (0 = auto-detect CPU count)." default:"0" name:"pdf-workers"`
+	Output     string        `short:"o" default:"deplexity-export" help:"Output directory."`
+	Format     []string      `short:"f" default:"json,markdown" help:"Export formats (json, markdown, pdf)." enum:"json,markdown,pdf"`
+	Threads    bool          `help:"Export threads." default:"true" negatable:""`
+	Spaces     bool          `help:"Export spaces/collections." default:"true" negatable:""`
+	Profile    bool          `help:"Export user profile." default:"true" negatable:""`
+	Delay      int           `help:"Delay between API requests in milliseconds." default:"500"`
+	Refresh    bool          `help:"Re-fetch the thread list and updated thread details." default:"false"`
+	PDFWorkers int           `help:"Number of parallel workers for PDF generation (0 = auto-detect CPU count)." default:"0" name:"pdf-workers"`
+	PDFTimeout time.Duration `help:"Maximum time to render one PDF (0 disables)." default:"30m" name:"pdf-timeout"`
 
 	verbose bool // set by main before Run
 }
@@ -86,6 +108,9 @@ func (cmd *ExportCmd) Run(ctx context.Context) error {
 	delay, err := requestDelay(cmd.Delay)
 	if err != nil {
 		return err
+	}
+	if cmd.PDFTimeout < 0 {
+		return fmt.Errorf("--pdf-timeout must be non-negative")
 	}
 
 	session, err := auth.LoadSession()
@@ -668,11 +693,6 @@ func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads [
 			}
 
 			var rendered atomic.Int64
-			workCh := make(chan int, workers)
-			errCh := make(chan error, 1)
-			pdfCtx, pdfCancel := context.WithCancel(ctx)
-			defer pdfCancel()
-			var wg sync.WaitGroup
 
 			// Progress printer (100ms ticker, normal mode only).
 			progressDone := make(chan struct{})
@@ -691,55 +711,29 @@ func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads [
 				}()
 			}
 
-			// Spawn workers.
-			for w := 0; w < workers; w++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					for i := range workCh {
-						if cmd.verbose {
-							fmt.Printf("  PDF: [%d/%d] %s\n", rendered.Load()+1, total, threads[i].Title)
-						}
-						if err := exp.ExportThread(&threads[i]); err != nil {
-							select {
-							case errCh <- err:
-							default:
-							}
-							pdfCancel()
-							return
-						}
-						rendered.Add(1)
-					}
-				}()
-			}
-
-			// Feed work.
-		feedLoop:
-			for i := range threads {
-				select {
-				case <-pdfCtx.Done():
-					break feedLoop
-				case workCh <- i:
+			err := runPDFWorkers(ctx, threads, workers, func(ctx context.Context, thread *models.Thread) error {
+				if cmd.verbose {
+					fmt.Printf("  PDF: [%d/%d] %s\n", rendered.Load()+1, total, thread.Title)
 				}
-			}
-			close(workCh)
-			wg.Wait()
+				if err := renderPDFIsolated(ctx, cmd.PDFTimeout, thread, exp.ThreadPDFPath(thread)); err != nil {
+					return err
+				}
+				rendered.Add(1)
+				return nil
+			})
 			close(progressDone)
 
 			// Final progress line.
 			n := rendered.Load()
-			if n < int64(total) && ctx.Err() != nil {
+			if ctx.Err() != nil {
 				fmt.Printf("\r  PDF: %d/%d threads (%d workers)\n", n, total, workers)
 				fmt.Printf("  Cancelling...\n")
 				return ctx.Err()
 			}
 			fmt.Printf("\r  PDF: %d/%d threads (%d workers)\n", n, total, workers)
 
-			// Check for worker errors.
-			select {
-			case err := <-errCh:
+			if err != nil {
 				return err
-			default:
 			}
 		}
 
@@ -750,6 +744,186 @@ func (cmd *ExportCmd) exportFormat(ctx context.Context, format string, threads [
 		}
 	}
 
+	return nil
+}
+
+type pdfRenderRequest struct {
+	Thread models.Thread `json:"thread"`
+}
+
+type pdfRenderFunc func(context.Context, *models.Thread) error
+
+func runPDFWorkers(ctx context.Context, threads []models.Thread, workers int, render pdfRenderFunc) error {
+	if len(threads) == 0 {
+		return ctx.Err()
+	}
+	if workers <= 0 {
+		return fmt.Errorf("PDF worker count must be positive")
+	}
+	pdfCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var next atomic.Int64
+	var firstErr error
+	var errOnce sync.Once
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				if pdfCtx.Err() != nil {
+					return
+				}
+				i := int(next.Add(1) - 1)
+				if i >= len(threads) {
+					return
+				}
+				if pdfCtx.Err() != nil {
+					return
+				}
+				if err := render(pdfCtx, &threads[i]); err != nil {
+					errOnce.Do(func() {
+						firstErr = err
+						cancel()
+					})
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return firstErr
+}
+
+func renderPDFIsolated(ctx context.Context, timeout time.Duration, thread *models.Thread, targetPath string) error {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return fmt.Errorf("could not create thread directory: %w", err)
+	}
+	staging, err := os.CreateTemp(filepath.Dir(targetPath), ".thread.pdf.render-*")
+	if err != nil {
+		return fmt.Errorf("could not create PDF staging file: %w", err)
+	}
+	stagingPath := staging.Name()
+	defer os.Remove(stagingPath)
+
+	renderCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		renderCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	request := pdfRenderRequest{Thread: *thread}
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("could not encode PDF render request: %w", err)
+	}
+	if len(requestJSON) > maxPDFRequestSize {
+		return fmt.Errorf("PDF render request for thread %q (%s) exceeds the %d-byte limit", thread.Title, thread.UUID, maxPDFRequestSize)
+	}
+	cmd, err := pdfCommand(renderCtx)
+	if err != nil {
+		return fmt.Errorf("could not locate PDF renderer: %w", err)
+	}
+	cmd.Stdin = bytes.NewReader(requestJSON)
+	cmd.Stdout = staging
+	var stderr limitedBuffer
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	if runErr != nil {
+		staging.Close()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if timeout > 0 && errors.Is(renderCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("PDF TIMEOUT: thread %q (%s) exceeded the %s per-thread limit; the renderer was terminated and no new PDF was published; any existing PDF was left unchanged; remaining PDF work was canceled", thread.Title, thread.UUID, timeout)
+		}
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return fmt.Errorf("render PDF for thread %q (%s): %s", thread.Title, thread.UUID, message)
+		}
+		return fmt.Errorf("render PDF for thread %q (%s): %w", thread.Title, thread.UUID, runErr)
+	}
+	if err := staging.Sync(); err != nil {
+		staging.Close()
+		return fmt.Errorf("could not flush PDF staging file: %w", err)
+	}
+	if err := staging.Close(); err != nil {
+		return fmt.Errorf("could not close PDF staging file: %w", err)
+	}
+	info, err := os.Stat(stagingPath)
+	if err != nil {
+		return fmt.Errorf("PDF renderer did not produce output for thread %q (%s): %w", thread.Title, thread.UUID, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("PDF renderer produced an empty file for thread %q (%s)", thread.Title, thread.UUID)
+	}
+	if err := os.Chmod(stagingPath, 0644); err != nil {
+		return fmt.Errorf("could not set PDF permissions: %w", err)
+	}
+	if err := os.Rename(stagingPath, targetPath); err != nil {
+		return fmt.Errorf("could not publish PDF for thread %q (%s): %w", thread.Title, thread.UUID, err)
+	}
+	return nil
+}
+
+type limitedBuffer struct {
+	data      []byte
+	truncated bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := maxPDFErrorSize - len(b.data)
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		b.data = append(b.data, p[:remaining]...)
+	}
+	if remaining < len(p) {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	if b.truncated {
+		return string(b.data) + "... [truncated]"
+	}
+	return string(b.data)
+}
+
+func runPDFRenderHelper(in io.Reader, out io.Writer) error {
+	requestJSON, err := io.ReadAll(io.LimitReader(in, maxPDFRequestSize+1))
+	if err != nil {
+		return fmt.Errorf("could not read PDF render request: %w", err)
+	}
+	if len(requestJSON) > maxPDFRequestSize {
+		return fmt.Errorf("PDF render request exceeds the %d-byte limit", maxPDFRequestSize)
+	}
+	var request pdfRenderRequest
+	decoder := json.NewDecoder(bytes.NewReader(requestJSON))
+	if err := decoder.Decode(&request); err != nil {
+		return fmt.Errorf("could not decode PDF render request: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("PDF render request contains trailing JSON")
+		}
+		return fmt.Errorf("could not validate PDF render request: %w", err)
+	}
+	data, err := export.GenerateThreadPDF(&request.Thread)
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write(data); err != nil {
+		return fmt.Errorf("could not write generated PDF: %w", err)
+	}
 	return nil
 }
 
@@ -806,6 +980,14 @@ func (cmd *VersionCmd) Run(_ context.Context) error {
 }
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == pdfHelperArg {
+		if err := runPDFRenderHelper(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/alecthomas/kong"
 
 	"github.com/clappingmonkey/deplexity/internal/export"
 	"github.com/clappingmonkey/deplexity/internal/models"
@@ -93,6 +99,277 @@ func TestExportRejectsNegativeDelayBeforeSessionLoad(t *testing.T) {
 	if err := cmd.Run(context.Background()); err == nil || err.Error() != "--delay must be non-negative" {
 		t.Fatalf("Run error = %v, want negative delay validation", err)
 	}
+}
+
+func TestExportRejectsNegativePDFTimeoutBeforeSessionLoad(t *testing.T) {
+	cmd := &ExportCmd{PDFTimeout: -time.Second}
+	err := cmd.Run(context.Background())
+	if err == nil || err.Error() != "--pdf-timeout must be non-negative" {
+		t.Fatalf("Run error = %v, want negative timeout validation", err)
+	}
+}
+
+func TestPDFTimeoutDefault(t *testing.T) {
+	var cli CLI
+	parser, err := kong.New(&cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parser.Parse([]string{"export"}); err != nil {
+		t.Fatal(err)
+	}
+	if cli.Export.PDFTimeout != 30*time.Minute {
+		t.Fatalf("PDFTimeout = %v, want 30m", cli.Export.PDFTimeout)
+	}
+}
+
+func TestRenderPDFIsolatedTimeoutIsExplicitAndPreservesExistingPDF(t *testing.T) {
+	restore := usePDFTestProcess(t, "block", "")
+	defer restore()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "thread.pdf")
+	if err := os.WriteFile(target, []byte("existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	thread := &models.Thread{UUID: "thread-123", Title: "Slow report"}
+	err := renderPDFIsolated(context.Background(), 50*time.Millisecond, thread, target)
+	if err == nil {
+		t.Fatal("expected PDF timeout")
+	}
+	for _, want := range []string{"PDF TIMEOUT", `thread "Slow report" (thread-123)`, "50ms per-thread limit", "renderer was terminated", "no new PDF was published", "existing PDF was left unchanged", "remaining PDF work was canceled"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("timeout error %q does not contain %q", err, want)
+		}
+	}
+	data, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("existing PDF = %q, want unchanged", data)
+	}
+	matches, globErr := filepath.Glob(filepath.Join(dir, ".thread.pdf.render-*"))
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("staging files remain after timeout: %v", matches)
+	}
+}
+
+func TestRenderPDFIsolatedCancellationTerminatesRenderer(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "started")
+	restore := usePDFTestProcess(t, "block", marker)
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	thread := &models.Thread{UUID: "thread-123", Title: "Canceled report"}
+	result := make(chan error, 1)
+	go func() {
+		result <- renderPDFIsolated(ctx, 30*time.Minute, thread, filepath.Join(t.TempDir(), "thread.pdf"))
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("renderer process did not start")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	start := time.Now()
+	cancel()
+	err := <-result
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("renderPDFIsolated error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("canceled renderer returned after %v", elapsed)
+	}
+}
+
+func TestRenderPDFIsolatedPublishesCompletedPDF(t *testing.T) {
+	restore := usePDFTestProcess(t, "write", "")
+	defer restore()
+
+	target := filepath.Join(t.TempDir(), "thread.pdf")
+	thread := &models.Thread{UUID: "thread-123", Title: "Completed report"}
+	if err := renderPDFIsolated(context.Background(), 0, thread, target); err != nil {
+		t.Fatalf("renderPDFIsolated: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "rendered" {
+		t.Fatalf("published PDF = %q, want rendered", data)
+	}
+}
+
+func TestRenderPDFIsolatedRejectsEmptyOutput(t *testing.T) {
+	restore := usePDFTestProcess(t, "empty", "")
+	defer restore()
+
+	target := filepath.Join(t.TempDir(), "thread.pdf")
+	thread := &models.Thread{UUID: "thread-123", Title: "Empty report"}
+	err := renderPDFIsolated(context.Background(), time.Minute, thread, target)
+	if err == nil || !strings.Contains(err.Error(), "produced an empty file") {
+		t.Fatalf("renderPDFIsolated error = %v, want empty output error", err)
+	}
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target PDF exists after empty output: %v", err)
+	}
+}
+
+func TestRenderPDFIsolatedZeroTimeoutHasNoInternalDeadline(t *testing.T) {
+	previous := pdfCommand
+	defer func() { pdfCommand = previous }()
+	pdfCommand = func(ctx context.Context) (*exec.Cmd, error) {
+		if _, ok := ctx.Deadline(); ok {
+			t.Fatal("zero PDF timeout added an internal deadline")
+		}
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestPDFRendererProcess")
+		cmd.Env = append(os.Environ(), "DEPLEXITY_PDF_TEST_PROCESS=1", "DEPLEXITY_PDF_TEST_MODE=write")
+		return cmd, nil
+	}
+	thread := &models.Thread{UUID: "thread-123", Title: "No timeout"}
+	if err := renderPDFIsolated(context.Background(), 0, thread, filepath.Join(t.TempDir(), "thread.pdf")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunPDFRenderHelper(t *testing.T) {
+	request, err := json.Marshal(pdfRenderRequest{Thread: models.Thread{UUID: "thread-123", Title: "Helper test"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := runPDFRenderHelper(bytes.NewReader(request), &output); err != nil {
+		t.Fatalf("runPDFRenderHelper: %v", err)
+	}
+	if output.Len() == 0 {
+		t.Fatal("helper produced an empty PDF")
+	}
+}
+
+func TestRunPDFRenderHelperRejectsInvalidInput(t *testing.T) {
+	if err := runPDFRenderHelper(strings.NewReader("not-json"), io.Discard); err == nil || !strings.Contains(err.Error(), "could not decode PDF render request") {
+		t.Fatalf("runPDFRenderHelper error = %v, want decode error", err)
+	}
+}
+
+func TestRunPDFRenderHelperRejectsTrailingJSON(t *testing.T) {
+	input := `{"thread":{"uuid":"thread-123"}} {"unexpected":true}`
+	if err := runPDFRenderHelper(strings.NewReader(input), io.Discard); err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("runPDFRenderHelper error = %v, want trailing JSON error", err)
+	}
+}
+
+func TestLimitedBufferCapsChildDiagnostics(t *testing.T) {
+	var buffer limitedBuffer
+	payload := strings.Repeat("x", maxPDFErrorSize+100)
+	if n, err := buffer.Write([]byte(payload)); err != nil || n != len(payload) {
+		t.Fatalf("Write = %d, %v", n, err)
+	}
+	if got := buffer.String(); len(got) > maxPDFErrorSize+len("... [truncated]") || !strings.HasSuffix(got, "... [truncated]") {
+		t.Fatalf("bounded diagnostics length/suffix = %d, %q", len(got), got[len(got)-20:])
+	}
+}
+
+func TestRunPDFWorkersStopsQueuedWorkAfterFailure(t *testing.T) {
+	threads := []models.Thread{{UUID: "first"}, {UUID: "second"}, {UUID: "queued"}}
+	failure := errors.New("render failed")
+	release := make(chan struct{})
+	defer close(release)
+	var calls atomic.Int64
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runPDFWorkers(context.Background(), threads, 2, func(ctx context.Context, thread *models.Thread) error {
+			calls.Add(1)
+			if thread.UUID == "first" {
+				return failure
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-release:
+				return nil
+			}
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, failure) {
+			t.Fatalf("runPDFWorkers error = %v, want render failure", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("workers did not stop after first failure")
+	}
+	if got := calls.Load(); got > 2 {
+		t.Fatalf("render calls = %d, want no queued work after failure", got)
+	}
+}
+
+func TestRunPDFWorkersCancellationStartsNoWork(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls atomic.Int64
+	err := runPDFWorkers(ctx, []models.Thread{{UUID: "thread"}}, 1, func(context.Context, *models.Thread) error {
+		calls.Add(1)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runPDFWorkers error = %v, want context.Canceled", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("render calls = %d, want 0", calls.Load())
+	}
+}
+
+func usePDFTestProcess(t *testing.T, mode, marker string) func() {
+	t.Helper()
+	previous := pdfCommand
+	pdfCommand = func(ctx context.Context) (*exec.Cmd, error) {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestPDFRendererProcess")
+		cmd.Env = append(os.Environ(), "DEPLEXITY_PDF_TEST_PROCESS=1", "DEPLEXITY_PDF_TEST_MODE="+mode, "DEPLEXITY_PDF_TEST_MARKER="+marker)
+		return cmd, nil
+	}
+	return func() { pdfCommand = previous }
+}
+
+func TestPDFRendererProcess(t *testing.T) {
+	if os.Getenv("DEPLEXITY_PDF_TEST_PROCESS") != "1" {
+		return
+	}
+	var request pdfRenderRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+		os.Exit(2)
+	}
+	if marker := os.Getenv("DEPLEXITY_PDF_TEST_MARKER"); marker != "" {
+		if err := os.WriteFile(marker, nil, 0600); err != nil {
+			os.Exit(5)
+		}
+	}
+	switch os.Getenv("DEPLEXITY_PDF_TEST_MODE") {
+	case "block":
+		for {
+			time.Sleep(time.Hour)
+		}
+	case "write":
+		if _, err := os.Stdout.Write([]byte("rendered")); err != nil {
+			os.Exit(3)
+		}
+	case "empty":
+	default:
+		os.Exit(4)
+	}
+	os.Exit(0)
 }
 
 func TestResumePoint(t *testing.T) {

--- a/internal/export/pdf.go
+++ b/internal/export/pdf.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -51,8 +52,39 @@ func (e *PDFExporter) Close() {}
 
 // ExportThread generates a PDF for a single thread.
 func (e *PDFExporter) ExportThread(thread *models.Thread) error {
-	dir := e.threadDir(thread)
-	return writeThreadPDF(dir, thread)
+	data, err := GenerateThreadPDF(thread)
+	if err != nil {
+		return err
+	}
+	path := e.ThreadPDFPath(thread)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("could not create thread directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".thread.pdf.tmp-*")
+	if err != nil {
+		return fmt.Errorf("could not create temporary PDF: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not write PDF file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not flush PDF file: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not set PDF permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("could not close temporary PDF: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("could not publish PDF file: %w", err)
+	}
+	return nil
 }
 
 // ExportSpaces generates PDFs for threads within each space folder.
@@ -73,8 +105,8 @@ func (e *PDFExporter) ExportSpaces(ctx context.Context, spaces []models.Space, t
 			if thread == nil {
 				continue
 			}
-			dir := filepath.Join(e.OutputDir, "spaces", spaceDirs[i], "threads", threadDirName(thread.Slug, thread.UUID))
-			if err := writeThreadPDF(dir, thread); err != nil {
+			dst := filepath.Join(e.OutputDir, "spaces", spaceDirs[i], "threads", threadDirName(thread.Slug, thread.UUID), "thread.pdf")
+			if err := copyFileContext(ctx, e.ThreadPDFPath(thread), dst); err != nil {
 				return err
 			}
 		}
@@ -82,12 +114,8 @@ func (e *PDFExporter) ExportSpaces(ctx context.Context, spaces []models.Space, t
 	return nil
 }
 
-// writeThreadPDF generates a PDF for a thread into the given directory.
-func writeThreadPDF(dir string, thread *models.Thread) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("could not create thread directory: %w", err)
-	}
-
+// GenerateThreadPDF generates PDF bytes for a thread.
+func GenerateThreadPDF(thread *models.Thread) ([]byte, error) {
 	doc := gpdf.NewDocument(
 		gpdf.WithPageSize(gpdf.Letter),
 		gpdf.WithMargins(document.Edges{
@@ -199,18 +227,77 @@ func writeThreadPDF(dir string, thread *models.Thread) error {
 
 	data, err := doc.Generate()
 	if err != nil {
-		return fmt.Errorf("could not generate PDF: %w", err)
+		return nil, fmt.Errorf("could not generate PDF: %w", err)
 	}
-
-	pdfPath := filepath.Join(dir, "thread.pdf")
-	if err := os.WriteFile(pdfPath, data, 0644); err != nil {
-		return fmt.Errorf("could not write PDF file: %w", err)
-	}
-
-	return nil
+	return data, nil
 }
 
-// threadDir returns the output directory for a thread.
-func (e *PDFExporter) threadDir(thread *models.Thread) string {
-	return filepath.Join(e.OutputDir, "threads", threadDirName(thread.Slug, thread.UUID))
+// ThreadPDFPath returns the canonical PDF path for a thread.
+func (e *PDFExporter) ThreadPDFPath(thread *models.Thread) string {
+	return filepath.Join(e.OutputDir, "threads", threadDirName(thread.Slug, thread.UUID), "thread.pdf")
+}
+
+func copyFileContext(ctx context.Context, src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("could not open source PDF: %w", err)
+	}
+	defer in.Close()
+	srcInfo, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("could not inspect source PDF: %w", err)
+	}
+	if !srcInfo.Mode().IsRegular() {
+		return fmt.Errorf("source PDF is not a regular file: %s", src)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("could not create space thread directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".thread.pdf.tmp-*")
+	if err != nil {
+		return fmt.Errorf("could not create temporary PDF: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	buf := make([]byte, 64*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			tmp.Close()
+			return err
+		}
+		n, readErr := in.Read(buf)
+		if n > 0 {
+			if _, err := tmp.Write(buf[:n]); err != nil {
+				tmp.Close()
+				return fmt.Errorf("could not copy PDF: %w", err)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			tmp.Close()
+			return fmt.Errorf("could not read source PDF: %w", readErr)
+		}
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not flush copied PDF: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("could not set PDF permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("could not close temporary PDF: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("could not publish space PDF: %w", err)
+	}
+	return nil
 }

--- a/internal/export/pdf_test.go
+++ b/internal/export/pdf_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,11 @@ func TestPDFExportSpacesUsesCanonicalDirectories(t *testing.T) {
 		{UUID: "thread-a", Slug: "same-slug", Title: "A"},
 		{UUID: "thread-b", Slug: "same-slug", Title: "B"},
 	}
+	for i := range threads {
+		if err := exporter.ExportThread(&threads[i]); err != nil {
+			t.Fatalf("ExportThread: %v", err)
+		}
+	}
 
 	if err := exporter.ExportSpaces(context.Background(), spaces, threads); err != nil {
 		t.Fatalf("ExportSpaces: %v", err)
@@ -34,5 +40,31 @@ func TestPDFExportSpacesUsesCanonicalDirectories(t *testing.T) {
 		if info.Size() == 0 {
 			t.Errorf("PDF %s is empty", pdfPath)
 		}
+		topLevel, err := os.ReadFile(exporter.ThreadPDFPath(&threads[i]))
+		if err != nil {
+			t.Fatal(err)
+		}
+		spaceCopy, err := os.ReadFile(pdfPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(spaceCopy) != string(topLevel) {
+			t.Errorf("space PDF differs from canonical thread PDF")
+		}
+	}
+}
+
+func TestPDFExportSpacesHonorsCancellationBeforeCopy(t *testing.T) {
+	dir := t.TempDir()
+	exporter := NewPDFExporter(dir)
+	thread := models.Thread{UUID: "thread-a", Slug: "thread-a", Title: "A"}
+	if err := exporter.ExportThread(&thread); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := exporter.ExportSpaces(ctx, []models.Space{{UUID: "space", Name: "Space", ThreadUUIDs: []string{thread.UUID}}}, []models.Thread{thread})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExportSpaces error = %v, want context.Canceled", err)
 	}
 }


### PR DESCRIPTION
## Description

Render each thread PDF in an isolated helper subprocess so Ctrl+C and a
per-thread timeout can terminate gpdf even when it is stuck inside synchronous
layout or pagination. Add `--pdf-timeout` with a 30-minute default and allow
`0` to disable automatic timeouts.

Completed PDFs are flushed and atomically published. Failed or timed-out renders
leave existing PDFs unchanged, clean up staging files, identify the affected
thread explicitly, cancel remaining PDF work, and exit non-zero. Space exports
copy the canonical thread PDF instead of rendering it again.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go test -race ./...`, `go vet ./...`,
  `bazel build //cmd/deplexity`, `bazel run //:gazelle`, repeated scoped race
  tests, `git diff --check`, and a real built-binary helper smoke render

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

PDF rendering now runs in cancellable helper processes with a configurable
30-minute per-thread timeout. A stuck renderer is terminated without replacing
an existing PDF, and the timeout error names the affected thread.

## Additional Context

No dependent PRs or Jira issue. Code review, adversarial validation, and security
audit approved the final stdout-only helper protocol. The local audit report is
not included in this PR.
