### PR TITLE
fix: report exported bookmark count

### DIFF
--- a/cmd/deplexity/main.go
+++ b/cmd/deplexity/main.go
@@ -298,6 +298,9 @@ func buildManifest(formats []string, threads []models.Thread, refs []models.Thre
 		if manifest.ThreadIndex[t.UUID] == "" {
 			manifest.ThreadIndex[t.UUID] = t.Slug
 		}
+		if t.Bookmarked {
+			manifest.Counts.Bookmarks++
+		}
 		for _, e := range t.Entries {
 			manifest.Counts.Sources += len(e.Sources)
 		}

--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -753,40 +753,60 @@ func TestFetchThreadDetailsPreservesSlugThroughCheckpointAndManifest(t *testing.
 	}
 }
 
-func TestFetchThreadDetailsMigratesLegacyCacheWithoutFetch(t *testing.T) {
-	dir := t.TempDir()
-	legacyDir := filepath.Join(dir, "threads", "thread-1")
-	if err := os.MkdirAll(legacyDir, 0755); err != nil {
-		t.Fatalf("create legacy directory: %v", err)
-	}
-	legacy := models.Thread{UUID: "thread-1", Slug: "thread-1", Complete: true}
-	data, err := json.Marshal(legacy)
-	if err != nil {
-		t.Fatalf("marshal legacy cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(legacyDir, "thread.json"), data, 0600); err != nil {
-		t.Fatalf("write legacy cache: %v", err)
-	}
-	jsonExp := &export.JSONExporter{OutputDir: dir}
-	ref := models.ThreadRef{UUID: "thread-1", Slug: "human-readable-slug"}
-	fetch := func(context.Context, string, *models.Thread, func(*models.Thread) error) (*models.Thread, error) {
-		t.Fatal("fetch called for complete legacy cache")
-		return nil, nil
+func TestFetchThreadDetailsRefetchesLegacyCachesFromStart(t *testing.T) {
+	tests := []struct {
+		name     string
+		complete bool
+		cursor   string
+	}{
+		{name: "complete cache", complete: true},
+		{name: "partial checkpoint", cursor: "legacy-cursor"},
 	}
 
-	cmd := &ExportCmd{}
-	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, []models.ThreadRef{ref}, fetch)
-	if err != nil {
-		t.Fatalf("fetchThreadDetails: %v", err)
-	}
-	if len(failures) != 0 || len(threads) != 1 || threads[0].Slug != ref.Slug {
-		t.Fatalf("threads=%#v failures=%#v", threads, failures)
-	}
-	if !jsonExp.HasCanonicalThread(ref) {
-		t.Fatal("legacy cache was not written to the canonical path")
-	}
-	if _, err := os.Stat(filepath.Join(legacyDir, "thread.json")); err != nil {
-		t.Errorf("legacy cache was removed: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			legacyDir := filepath.Join(dir, "threads", "thread-1")
+			if err := os.MkdirAll(legacyDir, 0755); err != nil {
+				t.Fatalf("create legacy directory: %v", err)
+			}
+			legacy := models.Thread{UUID: "thread-1", Slug: "thread-1", Complete: tt.complete, NextCursor: tt.cursor}
+			data, err := json.Marshal(legacy)
+			if err != nil {
+				t.Fatalf("marshal legacy cache: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(legacyDir, "thread.json"), data, 0600); err != nil {
+				t.Fatalf("write legacy cache: %v", err)
+			}
+			jsonExp := &export.JSONExporter{OutputDir: dir}
+			ref := models.ThreadRef{UUID: "thread-1", Slug: "human-readable-slug"}
+			var called bool
+			fetch := func(_ context.Context, uuid string, resume *models.Thread, _ func(*models.Thread) error) (*models.Thread, error) {
+				called = true
+				if resume != nil {
+					t.Fatalf("resume = %#v, want legacy cache fetched from page one", resume)
+				}
+				return &models.Thread{UUID: uuid, Slug: uuid, Bookmarked: true, Complete: true}, nil
+			}
+
+			cmd := &ExportCmd{}
+			threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, []models.ThreadRef{ref}, fetch)
+			if err != nil {
+				t.Fatalf("fetchThreadDetails: %v", err)
+			}
+			if !called {
+				t.Fatal("fetch was not called for legacy cache")
+			}
+			if len(failures) != 0 || len(threads) != 1 || threads[0].Slug != ref.Slug || !threads[0].Bookmarked {
+				t.Fatalf("threads=%#v failures=%#v", threads, failures)
+			}
+			if !jsonExp.HasCanonicalThread(ref) {
+				t.Fatal("legacy cache was not written to the canonical path")
+			}
+			if _, err := os.Stat(filepath.Join(legacyDir, "thread.json")); err != nil {
+				t.Errorf("legacy cache was removed: %v", err)
+			}
+		})
 	}
 }
 
@@ -995,33 +1015,35 @@ func TestFetchThreadDetailsCancellationPreservesPendingRetryState(t *testing.T) 
 func TestBuildManifestReportsThreadCompleteness(t *testing.T) {
 	threads := []models.Thread{
 		{
-			UUID:     "thread-1",
-			Slug:     "first",
-			Complete: true,
-			Entries:  []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+			UUID:       "thread-1",
+			Slug:       "first",
+			Bookmarked: true,
+			Complete:   true,
+			Entries:    []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
 		},
+		{UUID: "thread-2", Slug: "second", Complete: true},
 	}
-	failures := []models.ThreadExportFailure{{UUID: "thread-2", Stage: models.ThreadExportStageFetch, Error: "failed"}}
+	failures := []models.ThreadExportFailure{{UUID: "thread-3", Stage: models.ThreadExportStageFetch, Error: "failed"}}
 	account := &models.Account{GlobalSkills: []models.Skill{{ID: "skill-1"}}}
 
-	refs := []models.ThreadRef{{UUID: "thread-1", Slug: "first"}, {UUID: "thread-2", Slug: "failed-slug"}}
+	refs := []models.ThreadRef{{UUID: "thread-1", Slug: "first"}, {UUID: "thread-2", Slug: "second"}, {UUID: "thread-3", Slug: "failed-slug"}}
 	manifest := buildManifest([]string{"json"}, threads, refs, []models.Space{{UUID: "space-1"}}, account, failures)
 	if manifest.ThreadsComplete {
 		t.Fatal("ThreadsComplete = true, want false")
 	}
-	if manifest.ExpectedThreads != 2 || manifest.Counts.Threads != 1 {
-		t.Errorf("expected=%d exported=%d, want 2 and 1", manifest.ExpectedThreads, manifest.Counts.Threads)
+	if manifest.ExpectedThreads != 3 || manifest.Counts.Threads != 2 {
+		t.Errorf("expected=%d exported=%d, want 3 and 2", manifest.ExpectedThreads, manifest.Counts.Threads)
 	}
-	if manifest.Counts.Spaces != 1 || manifest.Counts.Sources != 1 || manifest.Counts.GlobalSkills != 1 {
-		t.Errorf("counts = %#v, want one space, source, and global skill", manifest.Counts)
+	if manifest.Counts.Spaces != 1 || manifest.Counts.Sources != 1 || manifest.Counts.Bookmarks != 1 || manifest.Counts.GlobalSkills != 1 {
+		t.Errorf("counts = %#v, want one space, source, bookmark, and global skill", manifest.Counts)
 	}
-	if len(manifest.FailedThreads) != 1 || manifest.FailedThreads[0].UUID != "thread-2" {
-		t.Errorf("FailedThreads = %#v, want thread-2", manifest.FailedThreads)
+	if len(manifest.FailedThreads) != 1 || manifest.FailedThreads[0].UUID != "thread-3" {
+		t.Errorf("FailedThreads = %#v, want thread-3", manifest.FailedThreads)
 	}
 	if manifest.ThreadIndex["thread-1"] != "first" {
 		t.Errorf("ThreadIndex = %#v, want exported thread", manifest.ThreadIndex)
 	}
-	if manifest.ThreadIndex["thread-2"] != "failed-slug" {
+	if manifest.ThreadIndex["thread-3"] != "failed-slug" {
 		t.Errorf("ThreadIndex = %#v, want failed thread list slug preserved", manifest.ThreadIndex)
 	}
 

--- a/internal/api/threads.go
+++ b/internal/api/threads.go
@@ -9,7 +9,10 @@ import (
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
-const apiVersion = "2.18"
+const (
+	apiVersion              = "2.18"
+	bookmarkStateBookmarked = "BOOKMARKED"
+)
 
 type getter interface {
 	Get(context.Context, string, any) error
@@ -212,6 +215,9 @@ func GetThread(ctx context.Context, c getter, uuid string, resume *models.Thread
 
 		// A cursor boundary can re-include the last entry, so dedupe by UUID.
 		for _, e := range page.Entries {
+			if e.BookmarkState == bookmarkStateBookmarked {
+				thread.Bookmarked = true
+			}
 			if seen[e.UUID] {
 				continue
 			}

--- a/internal/api/threads_test.go
+++ b/internal/api/threads_test.go
@@ -227,7 +227,7 @@ func TestGetThreadPaginatesByCursor(t *testing.T) {
 		},
 		{
 			// A cursor boundary re-includes the last entry of the prior page.
-			Entries:     []ThreadEntry{{UUID: "entry-2"}, {UUID: "entry-3"}},
+			Entries:     []ThreadEntry{{UUID: "entry-2", BookmarkState: "BOOKMARKED"}, {UUID: "entry-3"}},
 			HasNextPage: false,
 			NextCursor:  cursorPtr(""),
 		},
@@ -261,6 +261,39 @@ func TestGetThreadPaginatesByCursor(t *testing.T) {
 	}
 	if thread.NextCursor != "" {
 		t.Errorf("NextCursor = %q, want cleared on completion", thread.NextCursor)
+	}
+	if !thread.Bookmarked {
+		t.Error("bookmark state from duplicate cursor-boundary entry was not preserved")
+	}
+}
+
+func TestGetThreadMapsBookmarkState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{name: "bookmarked", state: "BOOKMARKED", want: true},
+		{name: "not bookmarked", state: "NOT_BOOKMARKED", want: false},
+		{name: "empty", state: "", want: false},
+		{name: "unknown", state: "UNKNOWN", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getter := &threadGetter{responses: []ThreadDetailResponse{{
+				Entries:     []ThreadEntry{{UUID: "entry-1", BookmarkState: tt.state}},
+				HasNextPage: false,
+			}}}
+
+			thread, err := GetThread(context.Background(), getter, "thread-1", nil, nil)
+			if err != nil {
+				t.Fatalf("GetThread: %v", err)
+			}
+			if thread.Bookmarked != tt.want {
+				t.Errorf("Bookmarked = %t, want %t for state %q", thread.Bookmarked, tt.want, tt.state)
+			}
+		})
 	}
 }
 
@@ -319,7 +352,7 @@ func TestGetThreadReturnsErrorWhenLaterPageFails(t *testing.T) {
 func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
 	getter := &threadGetter{responses: []ThreadDetailResponse{{
 		ThreadMetadata: ThreadMetadata{Title: "Long thread"},
-		Entries:        []ThreadEntry{{UUID: "entry-1"}, {UUID: "entry-2"}},
+		Entries:        []ThreadEntry{{UUID: "entry-1", BookmarkState: "BOOKMARKED"}, {UUID: "entry-2"}},
 		HasNextPage:    true,
 		NextCursor:     cursorPtr("cursor-1"),
 	}}}
@@ -348,6 +381,9 @@ func TestGetThreadCheckpointsProgressBeforeFailure(t *testing.T) {
 	if cp.Title != "Long thread" {
 		t.Errorf("checkpoint Title = %q, want metadata preserved", cp.Title)
 	}
+	if !cp.Bookmarked {
+		t.Error("checkpoint did not preserve bookmark state")
+	}
 }
 
 func TestGetThreadResumesFromCheckpoint(t *testing.T) {
@@ -364,6 +400,7 @@ func TestGetThreadResumesFromCheckpoint(t *testing.T) {
 		Slug:       "human-readable-slug",
 		Title:      "Long thread",
 		SpaceUUID:  "space-1",
+		Bookmarked: true,
 		Entries:    []models.Entry{{UUID: "entry-1"}, {UUID: "entry-2"}},
 		NextCursor: "cursor-1",
 	}
@@ -396,6 +433,9 @@ func TestGetThreadResumesFromCheckpoint(t *testing.T) {
 	}
 	if thread.Slug != resume.Slug || thread.SpaceUUID != resume.SpaceUUID {
 		t.Errorf("thread metadata = %#v, want resume slug and space preserved", thread)
+	}
+	if !thread.Bookmarked {
+		t.Error("completed thread did not preserve checkpoint bookmark state")
 	}
 }
 

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -11,6 +11,8 @@ import (
 	"github.com/clappingmonkey/deplexity/internal/models"
 )
 
+const threadCacheVersion = 1
+
 // JSONExporter writes data as formatted JSON files.
 type JSONExporter struct {
 	OutputDir string
@@ -75,7 +77,9 @@ func (e *JSONExporter) LoadThread(ref models.ThreadRef) (*models.Thread, error) 
 			if !os.IsNotExist(err) {
 				return nil, err
 			}
-			lastErr = err
+			if lastErr == nil {
+				lastErr = err
+			}
 			continue
 		}
 		var thread models.Thread
@@ -84,6 +88,10 @@ func (e *JSONExporter) LoadThread(ref models.ThreadRef) (*models.Thread, error) 
 		}
 		if thread.UUID != ref.UUID {
 			lastErr = fmt.Errorf("thread cache %s contains UUID %q, want %q", threadPath, thread.UUID, ref.UUID)
+			continue
+		}
+		if thread.CacheVersion != threadCacheVersion {
+			lastErr = fmt.Errorf("thread cache %s has version %d, want %d", threadPath, thread.CacheVersion, threadCacheVersion)
 			continue
 		}
 		return &thread, nil
@@ -111,13 +119,15 @@ func (e *JSONExporter) ExportThread(thread *models.Thread) error {
 	// copy first so a later sidecar failure cannot leave an older complete cache
 	// looking valid, then write the complete marker only after all sidecars.
 	threadPath := filepath.Join(dir, "thread.json")
-	if thread.Complete {
-		incomplete := *thread
+	current := *thread
+	current.CacheVersion = threadCacheVersion
+	if current.Complete {
+		incomplete := current
 		incomplete.Complete = false
 		if err := writeJSON(threadPath, &incomplete); err != nil {
 			return err
 		}
-	} else if err := writeJSON(threadPath, thread); err != nil {
+	} else if err := writeJSON(threadPath, &current); err != nil {
 		return err
 	}
 
@@ -131,8 +141,8 @@ func (e *JSONExporter) ExportThread(thread *models.Thread) error {
 			return err
 		}
 	}
-	if thread.Complete {
-		if err := writeJSON(threadPath, thread); err != nil {
+	if current.Complete {
+		if err := writeJSON(threadPath, &current); err != nil {
 			return err
 		}
 	}

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -36,6 +36,30 @@ func TestLoadCompleteThread(t *testing.T) {
 	if !loaded.Complete {
 		t.Fatal("loaded thread is not complete")
 	}
+	if loaded.CacheVersion != threadCacheVersion {
+		t.Errorf("CacheVersion = %d, want %d", loaded.CacheVersion, threadCacheVersion)
+	}
+}
+
+func TestLoadThreadRejectsLegacyCacheVersion(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	ref := models.ThreadRef{UUID: "thread-1", Slug: "thread-1"}
+	threadDir := filepath.Join(dir, "threads", threadDirName(ref.Slug, ref.UUID))
+	if err := os.MkdirAll(threadDir, 0755); err != nil {
+		t.Fatalf("create thread directory: %v", err)
+	}
+	data, err := json.Marshal(models.Thread{UUID: ref.UUID, Slug: ref.Slug, Complete: true})
+	if err != nil {
+		t.Fatalf("marshal legacy thread: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(threadDir, "thread.json"), data, 0600); err != nil {
+		t.Fatalf("write legacy thread: %v", err)
+	}
+
+	if _, err := exporter.LoadThread(ref); err == nil || !strings.Contains(err.Error(), "version 0") {
+		t.Fatalf("error = %v, want legacy cache version rejection", err)
+	}
 }
 
 func TestLoadCompleteThreadPreservesMetadata(t *testing.T) {
@@ -62,7 +86,7 @@ func TestLoadThreadFallsBackToLegacyUUIDDirectory(t *testing.T) {
 	if err := os.MkdirAll(legacyDir, 0755); err != nil {
 		t.Fatalf("create legacy directory: %v", err)
 	}
-	legacy := models.Thread{UUID: "thread-1", Slug: "thread-1", Complete: true}
+	legacy := models.Thread{UUID: "thread-1", Slug: "thread-1", Complete: true, CacheVersion: threadCacheVersion}
 	data, err := json.Marshal(legacy)
 	if err != nil {
 		t.Fatalf("marshal legacy thread: %v", err)
@@ -95,7 +119,7 @@ func TestLoadThreadUsesFirstMatchingUUIDCandidate(t *testing.T) {
 		if err := os.MkdirAll(candidateDir, 0755); err != nil {
 			t.Fatalf("create candidate directory: %v", err)
 		}
-		data, err := json.Marshal(models.Thread{UUID: uuid, Slug: slug, Title: title, Complete: true})
+		data, err := json.Marshal(models.Thread{UUID: uuid, Slug: slug, Title: title, Complete: true, CacheVersion: threadCacheVersion})
 		if err != nil {
 			t.Fatalf("marshal candidate: %v", err)
 		}
@@ -127,7 +151,7 @@ func TestLoadThreadUsesFirstMatchingUUIDCandidate(t *testing.T) {
 func TestLoadThreadFindsCanonicalCacheWrittenBeforeSlugWasKnown(t *testing.T) {
 	dir := t.TempDir()
 	exporter := &JSONExporter{OutputDir: dir}
-	thread := &models.Thread{UUID: "thread-1", Complete: true}
+	thread := &models.Thread{UUID: "thread-1", Complete: true, CacheVersion: threadCacheVersion}
 	if err := exporter.ExportThread(thread); err != nil {
 		t.Fatalf("ExportThread: %v", err)
 	}
@@ -155,7 +179,7 @@ func TestLoadThreadRejectsWrongUUIDInEveryCandidate(t *testing.T) {
 		if err := os.MkdirAll(candidateDir, 0755); err != nil {
 			t.Fatalf("create candidate directory: %v", err)
 		}
-		data, err := json.Marshal(models.Thread{UUID: "wrong-thread", Complete: true})
+		data, err := json.Marshal(models.Thread{UUID: "wrong-thread", Complete: true, CacheVersion: threadCacheVersion})
 		if err != nil {
 			t.Fatalf("marshal candidate: %v", err)
 		}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -16,15 +16,16 @@ type User struct {
 
 // Thread represents a conversation thread.
 type Thread struct {
-	UUID       string    `json:"uuid"`
-	Slug       string    `json:"slug"`
-	Title      string    `json:"title"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	SpaceUUID  string    `json:"space_uuid,omitempty"`
-	Entries    []Entry   `json:"entries,omitempty"`
-	Bookmarked bool      `json:"bookmarked,omitempty"`
-	Complete   bool      `json:"complete"`
+	UUID         string    `json:"uuid"`
+	Slug         string    `json:"slug"`
+	Title        string    `json:"title"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	SpaceUUID    string    `json:"space_uuid,omitempty"`
+	Entries      []Entry   `json:"entries,omitempty"`
+	Bookmarked   bool      `json:"bookmarked,omitempty"`
+	Complete     bool      `json:"complete"`
+	CacheVersion int       `json:"cache_version,omitempty"`
 	// NextCursor is the pagination cursor to resume from when Complete is
 	// false. The entries already fetched are persisted alongside it.
 	NextCursor string `json:"next_cursor,omitempty"`


### PR DESCRIPTION
## Description

Populate thread bookmark state from Perplexity detail responses and report the number of successfully exported bookmarked threads in `manifest.json`.

Version persisted thread caches so complete caches and partial checkpoints created before bookmark support are refetched from page one instead of silently treating unknown bookmark state as false.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go test -race ./...`, `go vet ./...`, `bazel build //cmd/deplexity`, and `git diff --check` pass; independent code review and adversarial validation approved the final diff.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Correct bookmark totals in export manifests. The first export after upgrading refetches existing thread caches once to populate bookmark metadata accurately.

## Additional Context

No dependent PRs. Legacy cache files are retained, but only cache version 1 files are reused or resumed.
