### PR TITLE
fix: remove stale source sidecars

### DIFF
--- a/cmd/deplexity/main_test.go
+++ b/cmd/deplexity/main_test.go
@@ -918,6 +918,71 @@ func TestFetchThreadDetailsFailedRefreshDoesNotUseStaleCache(t *testing.T) {
 	}
 }
 
+func TestFetchThreadDetailsReportsStaleSourcesCleanupFailure(t *testing.T) {
+	dir := t.TempDir()
+	jsonExp := &export.JSONExporter{OutputDir: dir}
+	oldUpdatedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	stale := &models.Thread{
+		UUID:      "thread-1",
+		Slug:      "thread-1",
+		UpdatedAt: oldUpdatedAt,
+		Complete:  true,
+		Entries:   []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+	}
+	if err := jsonExp.ExportThread(stale); err != nil {
+		t.Fatalf("seed stale thread: %v", err)
+	}
+	sourcePaths, err := filepath.Glob(filepath.Join(dir, "threads", "*", "sources.json"))
+	if err != nil {
+		t.Fatalf("find sources file: %v", err)
+	}
+	if len(sourcePaths) != 1 {
+		t.Fatalf("source paths = %v, want one", sourcePaths)
+	}
+	sourcesPath := sourcePaths[0]
+	if err := os.Remove(sourcesPath); err != nil {
+		t.Fatalf("remove sources file: %v", err)
+	}
+	if err := os.Mkdir(sourcesPath, 0755); err != nil {
+		t.Fatalf("create blocking sources directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcesPath, "keep"), []byte("blocked"), 0600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+	refs := []models.ThreadRef{{
+		UUID:              stale.UUID,
+		Slug:              stale.Slug,
+		UpdatedAt:         oldUpdatedAt.Add(time.Hour),
+		PreviousUpdatedAt: oldUpdatedAt,
+	}}
+	fetch := func(context.Context, string, *models.Thread, func(*models.Thread) error) (*models.Thread, error) {
+		return &models.Thread{UUID: stale.UUID, Slug: stale.Slug, UpdatedAt: refs[0].UpdatedAt, Complete: true}, nil
+	}
+
+	cmd := &ExportCmd{Refresh: true}
+	threads, failures, err := cmd.fetchThreadDetails(context.Background(), jsonExp, refs, fetch)
+	if err != nil {
+		t.Fatalf("fetchThreadDetails: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("thread counted as successful after cleanup failure: %#v", threads)
+	}
+	if len(failures) != 1 || failures[0].Stage != models.ThreadExportStageWrite || !strings.Contains(failures[0].Error, "remove stale sources") {
+		t.Fatalf("failures = %#v, want stale sources write failure", failures)
+	}
+	ref := models.ThreadRef{UUID: stale.UUID, Slug: stale.Slug}
+	if _, err := jsonExp.LoadCompleteThread(ref); err == nil {
+		t.Fatal("LoadCompleteThread accepted cache after cleanup failure")
+	}
+	partial, err := jsonExp.LoadThread(ref)
+	if err != nil {
+		t.Fatalf("LoadThread: %v", err)
+	}
+	if partial.Complete {
+		t.Fatal("thread cache remains complete after cleanup failure")
+	}
+}
+
 func TestFetchThreadDetailsCancellationTakesPrecedence(t *testing.T) {
 	jsonExp := &export.JSONExporter{OutputDir: t.TempDir()}
 	refs := []models.ThreadRef{{UUID: "thread-1"}, {UUID: "thread-2"}}

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -131,15 +131,8 @@ func (e *JSONExporter) ExportThread(thread *models.Thread) error {
 		return err
 	}
 
-	// Write sources separately for easy access
-	var allSources []models.Source
-	for _, entry := range thread.Entries {
-		allSources = append(allSources, entry.Sources...)
-	}
-	if len(allSources) > 0 {
-		if err := writeJSON(filepath.Join(dir, "sources.json"), allSources); err != nil {
-			return err
-		}
+	if err := writeThreadSources(dir, thread); err != nil {
+		return err
 	}
 	if current.Complete {
 		if err := writeJSON(threadPath, &current); err != nil {
@@ -240,18 +233,11 @@ func (e *JSONExporter) ExportSpaces(ctx context.Context, spaces []models.Space, 
 			if err := os.MkdirAll(threadDir, 0755); err != nil {
 				return fmt.Errorf("could not create space thread directory: %w", err)
 			}
-			if err := writeJSON(filepath.Join(threadDir, "thread.json"), thread); err != nil {
+			if err := writeThreadSources(threadDir, thread); err != nil {
 				return err
 			}
-			// Write sources separately.
-			var allSources []models.Source
-			for _, entry := range thread.Entries {
-				allSources = append(allSources, entry.Sources...)
-			}
-			if len(allSources) > 0 {
-				if err := writeJSON(filepath.Join(threadDir, "sources.json"), allSources); err != nil {
-					return err
-				}
+			if err := writeJSON(filepath.Join(threadDir, "thread.json"), thread); err != nil {
+				return err
 			}
 		}
 	}
@@ -300,6 +286,23 @@ func (e *JSONExporter) ExportManifest(manifest *models.ExportManifest) error {
 // threadDir returns the output directory for a thread.
 func (e *JSONExporter) threadDir(thread *models.Thread) string {
 	return filepath.Join(e.OutputDir, "threads", threadDirName(thread.Slug, thread.UUID))
+}
+
+// writeThreadSources keeps the optional sources sidecar in sync with thread data.
+func writeThreadSources(dir string, thread *models.Thread) error {
+	var sources []models.Source
+	for _, entry := range thread.Entries {
+		sources = append(sources, entry.Sources...)
+	}
+
+	sourcesPath := filepath.Join(dir, "sources.json")
+	if len(sources) > 0 {
+		return writeJSON(sourcesPath, sources)
+	}
+	if err := os.Remove(sourcesPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not remove stale sources file %s: %w", sourcesPath, err)
+	}
+	return nil
 }
 
 // writeSpaceSkills writes each skill's SKILL.md body into a skills/ subfolder

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -223,6 +223,64 @@ func TestExportThreadMarksCacheIncompleteUntilSidecarsSucceed(t *testing.T) {
 	}
 }
 
+func TestExportThreadRemovesStaleSources(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	thread := &models.Thread{
+		UUID:     "thread-1",
+		Slug:     "thread-1",
+		Complete: true,
+		Entries:  []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+	}
+	if err := exporter.ExportThread(thread); err != nil {
+		t.Fatalf("ExportThread with sources: %v", err)
+	}
+	sourcesPath := filepath.Join(exporter.threadDir(thread), "sources.json")
+	if _, err := os.Stat(sourcesPath); err != nil {
+		t.Fatalf("sources.json was not written: %v", err)
+	}
+
+	thread.Entries = nil
+	if err := exporter.ExportThread(thread); err != nil {
+		t.Fatalf("ExportThread without sources: %v", err)
+	}
+	if _, err := os.Stat(sourcesPath); !os.IsNotExist(err) {
+		t.Fatalf("stale sources.json remains (err=%v)", err)
+	}
+	if _, err := exporter.LoadCompleteThread(models.ThreadRef{UUID: thread.UUID, Slug: thread.Slug}); err != nil {
+		t.Fatalf("LoadCompleteThread after cleanup: %v", err)
+	}
+}
+
+func TestExportThreadCleanupFailureLeavesCacheIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	thread := &models.Thread{UUID: "thread-1", Slug: "thread-1", Complete: true}
+	threadDir := exporter.threadDir(thread)
+	sourcesPath := filepath.Join(threadDir, "sources.json")
+	if err := os.MkdirAll(sourcesPath, 0755); err != nil {
+		t.Fatalf("create blocking sources directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcesPath, "keep"), []byte("blocked"), 0600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	if err := exporter.ExportThread(thread); err == nil || !strings.Contains(err.Error(), "remove stale sources") {
+		t.Fatalf("error = %v, want stale sources removal failure", err)
+	}
+	ref := models.ThreadRef{UUID: thread.UUID, Slug: thread.Slug}
+	if _, err := exporter.LoadCompleteThread(ref); err == nil {
+		t.Fatal("LoadCompleteThread accepted cache after sidecar cleanup failure")
+	}
+	partial, err := exporter.LoadThread(ref)
+	if err != nil {
+		t.Fatalf("LoadThread: %v", err)
+	}
+	if partial.Complete {
+		t.Fatal("thread.json remains complete after sidecar cleanup failure")
+	}
+}
+
 func TestExportSpacesWritesInstructionsAndSkills(t *testing.T) {
 	dir := t.TempDir()
 	exporter := &JSONExporter{OutputDir: dir}
@@ -369,6 +427,75 @@ func TestExportSpacesSeparatesCollidingThreadSlugs(t *testing.T) {
 		if written.UUID != thread.UUID {
 			t.Errorf("%s contains UUID %q, want %q", path, written.UUID, thread.UUID)
 		}
+	}
+}
+
+func TestExportSpacesRemovesStaleThreadSources(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	space := models.Space{UUID: "space-1", Name: "Space", ThreadUUIDs: []string{"thread-1"}}
+	thread := models.Thread{
+		UUID:    "thread-1",
+		Slug:    "thread-1",
+		Entries: []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+	}
+	if err := exporter.ExportSpaces(context.Background(), []models.Space{space}, []models.Thread{thread}); err != nil {
+		t.Fatalf("ExportSpaces with sources: %v", err)
+	}
+	threadDir := filepath.Join(dir, "spaces", spaceDirNames([]models.Space{space})[0], "threads", threadDirName(thread.Slug, thread.UUID))
+	sourcesPath := filepath.Join(threadDir, "sources.json")
+	if _, err := os.Stat(sourcesPath); err != nil {
+		t.Fatalf("space sources.json was not written: %v", err)
+	}
+
+	thread.Entries = nil
+	if err := exporter.ExportSpaces(context.Background(), []models.Space{space}, []models.Thread{thread}); err != nil {
+		t.Fatalf("ExportSpaces without sources: %v", err)
+	}
+	if _, err := os.Stat(sourcesPath); !os.IsNotExist(err) {
+		t.Fatalf("stale space sources.json remains (err=%v)", err)
+	}
+}
+
+func TestExportSpacesReportsStaleThreadSourcesCleanupFailure(t *testing.T) {
+	dir := t.TempDir()
+	exporter := &JSONExporter{OutputDir: dir}
+	space := models.Space{UUID: "space-1", Name: "Space", ThreadUUIDs: []string{"thread-1"}}
+	thread := models.Thread{
+		UUID:    "thread-1",
+		Slug:    "thread-1",
+		Entries: []models.Entry{{Sources: []models.Source{{URL: "https://example.com"}}}},
+	}
+	if err := exporter.ExportSpaces(context.Background(), []models.Space{space}, []models.Thread{thread}); err != nil {
+		t.Fatalf("ExportSpaces with sources: %v", err)
+	}
+	threadDir := filepath.Join(dir, "spaces", spaceDirNames([]models.Space{space})[0], "threads", threadDirName(thread.Slug, thread.UUID))
+	sourcesPath := filepath.Join(threadDir, "sources.json")
+	if err := os.Remove(sourcesPath); err != nil {
+		t.Fatalf("remove sources file: %v", err)
+	}
+	if err := os.Mkdir(sourcesPath, 0755); err != nil {
+		t.Fatalf("create blocking sources directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcesPath, "keep"), []byte("blocked"), 0600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	thread.Entries = nil
+	if err := exporter.ExportSpaces(context.Background(), []models.Space{space}, []models.Thread{thread}); err == nil || !strings.Contains(err.Error(), "remove stale sources") {
+		t.Fatalf("error = %v, want stale sources cleanup failure", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(threadDir, "thread.json"))
+	if err != nil {
+		t.Fatalf("read previous thread.json: %v", err)
+	}
+	var previous models.Thread
+	if err := json.Unmarshal(data, &previous); err != nil {
+		t.Fatalf("unmarshal previous thread.json: %v", err)
+	}
+	if len(previous.Entries) != 1 {
+		t.Fatalf("thread.json was replaced despite cleanup failure: %#v", previous)
 	}
 }
 


### PR DESCRIPTION
## Description

Keep `sources.json` synchronized with refreshed thread data. When a thread no longer contains sources, remove the stale sidecar from both canonical thread directories and self-contained thread copies under spaces.

Cleanup failures remain observable: canonical caches stay incomplete, and existing space `thread.json` files are not replaced when their stale sidecar cannot be removed.

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build configuration
- [ ] Dependency update

## Testing

- [x] `bazel test //...` passes
- [x] Manual verification: `go test -race ./...`, `go vet ./...`, `bazel build //cmd/deplexity`, and `git diff --check` pass. Regression tests cover canonical and space-copy cleanup success and failure, plus refresh failure classification and incomplete-cache behavior.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `bazel run //:gazelle` run (if Go files added/changed)
- [x] No secrets or credentials introduced
- [x] Documentation updated (if applicable)

## Release Notes

Remove obsolete `sources.json` files when refreshed conversations no longer contain citations.

## Additional Context

No dependent PRs. Independent code review and adversarial validation approved the final diff with no findings.
